### PR TITLE
Refactoring the Runtime class

### DIFF
--- a/src/php/Runtime.php
+++ b/src/php/Runtime.php
@@ -29,38 +29,38 @@ class Runtime {
     /**
      * @var string|null
      */
-    private $cacheDiretory;
+    private $cacheDirectory;
 
     /**
      * @var Runtime|null
      */
     private static $instance;
 
-    private function __construct(GlobalEnvironment $globalEnv = null, string $cacheDiretory = null) {
+    private function __construct(GlobalEnvironment $globalEnv = null, string $cacheDirectory = null) {
         set_exception_handler(array($this, 'exceptionHandler'));
 
         if (is_null($globalEnv)) {
             $globalEnv = new GlobalEnvironment();
         }
         $this->globalEnv = $globalEnv;
-        $this->cacheDiretory = $cacheDiretory;
+        $this->cacheDirectory = $cacheDirectory;
         $this->addPath('phel\\', [__DIR__ . '/../phel']);
     }
 
-    public static function initialize(GlobalEnvironment $globalEnv = null, string $cacheDiretory = null) {
+    public static function initialize(GlobalEnvironment $globalEnv = null, string $cacheDirectory = null) {
         if (self::$instance !== null) {
             throw new Exception("Runtime is already initialized");
         }
 
-        self::$instance = new Runtime($globalEnv, $cacheDiretory);
+        self::$instance = new Runtime($globalEnv, $cacheDirectory);
         return self::$instance;
     }
 
     /**
      * @interal
      */
-    public static function newInstance(GlobalEnvironment $globalEnv = null, string $cacheDiretory = null) {
-        return new Runtime($globalEnv, $cacheDiretory);
+    public static function newInstance(GlobalEnvironment $globalEnv = null, string $cacheDirectory = null) {
+        return new Runtime($globalEnv, $cacheDirectory);
     }
 
     /**
@@ -121,8 +121,8 @@ class Runtime {
     }
 
     protected function getCachedFilePath(string $file, string $ns): ?string {
-        if ($this->cacheDiretory) {
-            return $this->cacheDiretory 
+        if ($this->cacheDirectory) {
+            return $this->cacheDirectory 
                 . DIRECTORY_SEPARATOR
                 . str_replace('\\', '.', $ns) 
                 . '.' . md5_file($file)

--- a/src/php/Runtime.php
+++ b/src/php/Runtime.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel;
 
 use Exception;
@@ -11,30 +13,16 @@ use Phel\Lang\Table;
 
 class Runtime {
 
-    /**
-     * @var GlobalEnvironment
-     */
-    private $globalEnv;
+    private GlobalEnvironment $globalEnv;
 
-    /**
-     * @var string[]
-     */
-    private $loadedNs = [];
+    /** @var string[] */
+    private array $loadedNs = [];
 
-    /**
-     * @var array
-     */
-    private $paths = [];
+    private array $paths = [];
 
-    /**
-     * @var string|null
-     */
-    private $cacheDirectory;
+    private ?string $cacheDirectory = null;
 
-    /**
-     * @var Runtime|null
-     */
-    private static $instance;
+    private static ?Runtime $instance = null;
 
     private function __construct(GlobalEnvironment $globalEnv = null, string $cacheDirectory = null) {
         set_exception_handler(array($this, 'exceptionHandler'));
@@ -59,15 +47,12 @@ class Runtime {
     /**
      * @interal
      */
-    public static function newInstance(GlobalEnvironment $globalEnv = null, string $cacheDirectory = null) {
+    public static function newInstance(GlobalEnvironment $globalEnv = null, string $cacheDirectory = null): self {
         return new Runtime($globalEnv, $cacheDirectory);
     }
 
-    /**
-     * @param Exception $exception
-     */
-    public function exceptionHandler($exception) {
-        if (php_sapi_name() == 'cli') {
+    public function exceptionHandler(Exception $exception): void {
+        if (php_sapi_name() === 'cli') {
             $printer = new TextExceptionPrinter();
         } else {
             $printer = new HtmlExceptionPrinter();
@@ -105,9 +90,9 @@ class Runtime {
 
                 if ($this->isCached($file, $ns)) {
                     return $this->loadCachedFile($file, $ns);
-                } else {    
-                    return $this->loadFile($file, $ns);
                 }
+
+                return $this->loadFile($file, $ns);
             }
         }
 
@@ -127,9 +112,9 @@ class Runtime {
                 . str_replace('\\', '.', $ns) 
                 . '.' . md5_file($file)
                 . '.php';
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**

--- a/src/php/Runtime.php
+++ b/src/php/Runtime.php
@@ -10,6 +10,7 @@ use Phel\Exceptions\TextExceptionPrinter;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Lang\Table;
+use Throwable;
 
 class Runtime {
 
@@ -51,7 +52,7 @@ class Runtime {
         return new Runtime($globalEnv, $cacheDirectory);
     }
 
-    public function exceptionHandler(Exception $exception): void {
+    public function exceptionHandler(Throwable $exception): void {
         if (php_sapi_name() === 'cli') {
             $printer = new TextExceptionPrinter();
         } else {


### PR DESCRIPTION
# Description

Improvements applied to the `Phel\Runtime` class:

* Fixed the typo
  * from: "cacheDiretory" (the "c" of the "Dire**c**tory" word is missing!)
  * to: "cacheDirectory"
* Applying `strict_types`
* Remove unnecesary "elses"