### PR TITLE
Cleaning Analyzer class

### DIFF
--- a/src/php/Analyzer.php
+++ b/src/php/Analyzer.php
@@ -115,10 +115,14 @@ final class Analyzer {
             return $this->analyzeTable($x, $nodeEnvironment);
         }
 
-        if (!$x instanceof Tuple) {
-            throw new AnalyzerException('Unhandled type: ' . var_export($x, true), null, null);
+        if ($x instanceof Tuple) {
+            return $this->analyzeTuple($x, $nodeEnvironment);
         }
 
+        throw new AnalyzerException('Unhandled type: ' . var_export($x, true), null, null);
+    }
+
+    private function analyzeTuple(Tuple $x, NodeEnvironment $nodeEnvironment): Node {
         if (!$x[0] instanceof Symbol) {
             return $this->analyzeInvoke($x, $nodeEnvironment);
         }


### PR DESCRIPTION
# Description

* Making the class [strict](https://github.com/Chemaclass/php-best-practices/blob/master/technical-skills/strict-types.md)
* Making the class [final](https://medium.com/@chemaclass/final-classes-in-php-9174e3e2747e)
* Using [strict comparations](https://github.com/Chemaclass/php-best-practices/blob/master/technical-skills/performance-tips.md): `===` instead of `==`
* Removing unnecessary `else` statements due to return early (really good job there!)
  * It also decreases the indentation of the blocks which helps a lot to follow the logic
* Change from `protected $phpKeywords` to `private const PHP_KEYWORDS` you might guess why :)
