### PR TITLE
Using null coalescing operator

### DIFF
--- a/src/php/Exceptions/HtmlExceptionPrinter.php
+++ b/src/php/Exceptions/HtmlExceptionPrinter.php
@@ -62,7 +62,7 @@ class HtmlExceptionPrinter implements ExceptionPrinter
 
         echo "<ul>";
         foreach ($e->getTrace() as $i => $frame) {
-            $class = isset($frame['class']) ? $frame['class'] : null;
+            $class = $frame['class'] ?? null;
             $file = $frame['file'];
             $line = $frame['line'];
 

--- a/src/php/Exceptions/TextExceptionPrinter.php
+++ b/src/php/Exceptions/TextExceptionPrinter.php
@@ -59,7 +59,7 @@ class TextExceptionPrinter implements ExceptionPrinter
         echo "in $file:$line (gen: $generatedLine:$generetedColumn)\n\n";
 
         foreach ($e->getTrace() as $i => $frame) {
-            $class = isset($frame['class']) ? $frame['class'] : null;
+            $class = $frame['class'] ?? null;
             $generatedLine = $frame['file'];
             $generetedColumn = $frame['line'];
 
@@ -176,6 +176,6 @@ class TextExceptionPrinter implements ExceptionPrinter
             'blue'   => "\033[33;34m%s\033[0m",
         );
 
-        return sprintf(isset($styles[$color]) ? $styles[$color] : "%s", $text);
+        return sprintf($styles[$color] ?? "%s", $text);
     }
 }

--- a/src/php/Lang/PhelArray.php
+++ b/src/php/Lang/PhelArray.php
@@ -75,7 +75,7 @@ class PhelArray extends Phel implements ArrayAccess, Countable, Iterator, ICons,
      */
     public function offsetGet($offset)
     {
-        return isset($this->data[$offset]) ? $this->data[$offset] : null;
+        return $this->data[$offset] ?? null;
     }
 
     public function count(): int

--- a/src/php/Lang/Table.php
+++ b/src/php/Lang/Table.php
@@ -85,7 +85,7 @@ class Table extends Phel implements ArrayAccess, Countable, Iterator
     {
         $hash = $this->offsetHash($offset);
 
-        return isset($this->data[$hash]) ? $this->data[$hash] : null;
+        return $this->data[$hash] ?? null;
     }
 
     public function count(): int

--- a/src/php/Lang/Tuple.php
+++ b/src/php/Lang/Tuple.php
@@ -77,7 +77,7 @@ class Tuple extends Phel implements ArrayAccess, Countable, Iterator, ISlice, IC
      */
     public function offsetGet($offset)
     {
-        return isset($this->data[$offset]) ? $this->data[$offset] : null;
+        return $this->data[$offset] ?? null;
     }
 
     public function count()

--- a/src/php/Repl.php
+++ b/src/php/Repl.php
@@ -93,7 +93,7 @@ class Repl
             'blue'   => "\033[33;34m%s\033[0m",
         );
 
-        return sprintf(isset($styles[$color]) ? $styles[$color] : "%s", $text);
+        return sprintf($styles[$color] ?? "%s", $text);
     }
 
     protected function input()


### PR DESCRIPTION
# Description

Using null coalescing operator `$foo ?? $bar` instead of `isset($foo) ? $foo : $bar`

[Modern PHP: know the best PHP features up to PHP 7.4](https://medium.com/@chemaclass/modern-php-know-the-best-php-features-til-php-7-4-e3b2bf5916b2)