### PR TITLE
remove trailing spaces

### DIFF
--- a/doc/content/documentation/api.md
+++ b/doc/content/documentation/api.md
@@ -16,7 +16,7 @@ Return the remainder of `dividend` / `divisor`.
 ```phel
 (* & xs)
 ```
-Returns the product of all elements in `xs`. All elements in `xs` must be 
+Returns the product of all elements in `xs`. All elements in `xs` must be
 numbers. If `xs` is empty, return 1.
 
 ## `**`
@@ -105,9 +105,9 @@ Returns true if `(pred x)` is logical true for every `x` in `xs`, else false.
 ```phel
 (and & args)
 ```
-Evaluates each expression one at a time, from left to right. If a form 
-returns logical false, and returns that value and doesn't evaluate any of the 
-other expressions, otherwise it returns the value of the last expression. 
+Evaluates each expression one at a time, from left to right. If a form
+returns logical false, and returns that value and doesn't evaluate any of the
+other expressions, otherwise it returns the value of the last expression.
 Calling the and function without arguments returns true.
 
 ## `array`
@@ -207,9 +207,9 @@ Returns true if `x` is a boolean, false otherwise.
 (case e & pairs)
 ```
 Takes an expression `e` and a set of test-content/expression pairs. First
-  evaluates `e` and the then finds the first pair where the test-constant matches 
-  the result of `e`. The associated expression is then evaluated and returned. 
-  If no matches can be found a final last expression can be provided that is 
+  evaluates `e` and the then finds the first pair where the test-constant matches
+  the result of `e`. The associated expression is then evaluated and returned.
+  If no matches can be found a final last expression can be provided that is
   than evaluated and return. Otherwise nil is returned.
 
 ## `comment`
@@ -231,7 +231,7 @@ Ignores the body of the comment
 ```phel
 (compare x y)
 ```
-An integer less than, equal to, or greater than zero when `x` is less than, 
+An integer less than, equal to, or greater than zero when `x` is less than,
   equal to, or greater than `y`, respectively.
 
 ## `complement`
@@ -270,7 +270,7 @@ Prepends `x` to the beginning of `xs`
 ```phel
 (count xs)
 ```
-Counts the number of elements in a sequence. Can be used on everything that 
+Counts the number of elements in a sequence. Can be used on everything that
 implement the PHP Countable interface.
 
 ## `dec`
@@ -418,7 +418,7 @@ Returns the first element of an indexed sequence or nil.
 ```phel
 (flatten xs)
 ```
-Takes a nested sequential data structure (tree), and returns their contents 
+Takes a nested sequential data structure (tree), and returns their contents
   as a single, flat array.
 
 ## `float?`
@@ -454,7 +454,7 @@ Generates a new unique symbol.
 ```phel
 (get ds k & [opt])
 ```
-Get the value mapped to `key` from the datastructure `ds`. 
+Get the value mapped to `key` from the datastructure `ds`.
   Returns `opt` or nil if the value can not be found.
 
 ## `get-in`
@@ -597,7 +597,7 @@ Returns an array of key value pairs like @[k1 v1 k2 v2 k3 v3 ...].
 ```phel
 (map-indexed f xs)
 ```
-Applies f to each element in xs. f is a two argument function. The first 
+Applies f to each element in xs. f is a two argument function. The first
   argument is index of the element in the sequence and the second element is the
   element itself.
 
@@ -664,7 +664,7 @@ Checks if `x` is smaller than zero.
 ```phel
 (next xs)
 ```
-Returns the sequence of elements after the first element. If there are no 
+Returns the sequence of elements after the first element. If there are no
 elements, returns nil.
 
 ## `nfirst`
@@ -693,7 +693,7 @@ Same as `(next (next xs))`
 ```phel
 (not x)
 ```
-The `not` function returns `true` if the given value is logical false and 
+The `not` function returns `true` if the given value is logical false and
 `false` otherwise.
 
 ## `not=`
@@ -729,9 +729,9 @@ Checks if `x` is one.
 ```phel
 (or & args)
 ```
-Evaluates each expression one at a time, from left to right. If a form 
-returns a logical true value, or returns that value and doesn't evaluate any of 
-the other expressions, otherwise it returns the value of the last expression. 
+Evaluates each expression one at a time, from left to right. If a form
+returns a logical true value, or returns that value and doesn't evaluate any of
+the other expressions, otherwise it returns the value of the last expression.
 Calling or without arguments, returns nil.
 
 ## `pairs`
@@ -781,7 +781,7 @@ Returns true if `x` is a PHP resource, false otherwise.
 ```phel
 (pop xs)
 ```
-Removes the the last element of the array `xs`. If the array is empty 
+Removes the the last element of the array `xs`. If the array is empty
   returns nil.
 
 ## `pos?`
@@ -889,7 +889,7 @@ Returns an array of length n where every element is x.
 ```phel
 (rest xs)
 ```
-Returns the sequence of elements after the first element. If there are no 
+Returns the sequence of elements after the first element. If there are no
 elements, returns an empty sequence.
 
 ## `reverse`
@@ -939,7 +939,7 @@ Returns a sorted array. If no comperator is supplied compare is used.
 ```phel
 (sort-by keyfn xs & [comp])
 ```
-Returns a sorted array where the sort order is determined by comparing 
+Returns a sorted array where the sort order is determined by comparing
   (keyfn item). If no comperator is supplied compare is used.
 
 ## `split-at`
@@ -961,9 +961,9 @@ Returns a tuple of [(take-while pred coll) (drop-while pred coll)]
 ```phel
 (str & args)
 ```
-Creates a string by concatenating values together. If no arguments are 
-provided an empty string is returned. Nil and false are represented as empty 
-string. True is represented as 1. Otherwise it tries to call `__toString`. 
+Creates a string by concatenating values together. If no arguments are
+provided an empty string is returned. Nil and false are represented as empty
+string. True is represented as 1. Otherwise it tries to call `__toString`.
 This is PHP equalivalent to `$args[0] . $args[1] . $args[2] ...`
 
 ## `string?`
@@ -999,7 +999,7 @@ Returns true if `x` is a symbol, false otherwise.
 ```phel
 (table & xs)
 ```
-Creates a new Table. If no argument is provided, an empty Table is created. 
+Creates a new Table. If no argument is provided, an empty Table is created.
 The number of parameters must be even.
 
 ## `table?`
@@ -1036,7 +1036,7 @@ Create a PHP Array from a sequential data structure
 (tree-seq branch? children root)
 ```
 Returns an array of the nodes in the tree, via a depth first walk.
-  branch? is a function with one argument that returns true if the given node 
+  branch? is a function with one argument that returns true if the given node
   has children.
   children must be a function with one argument that returns the children of the node.
   root the the root node of the tree.
@@ -1067,7 +1067,7 @@ Creates a new Tuple. If no argument is provided, an empty Tuple is created.
 ```phel
 (tuple-brackets & xs)
 ```
-Creates a new Bracket-Tuple. If no argument is provided, 
+Creates a new Bracket-Tuple. If no argument is provided,
 an empty Braket-Tuple is created.
 
 ## `tuple?`
@@ -1085,7 +1085,7 @@ Returns true if `x` is a tuple, false otherwise.
 Returns the type of `x`. Following types can be returned:
 
 * `:tuple`
-* `:array` 
+* `:array`
 * `:struct`
 * `:table`
 * `:keyword`

--- a/doc/content/documentation/array-table-and-struct.md
+++ b/doc/content/documentation/array-table-and-struct.md
@@ -43,7 +43,7 @@ Similar to tuples the functions `get`, `first`, `second`, `next` and `rest` can 
 The `get` function can also be use on tables.
 
 ```phel
-(get @{:a 1 :b 2} :a) # Evaluates to 1 
+(get @{:a 1 :b 2} :a) # Evaluates to 1
 (get @{:a 1 :b 2} :b) # Evaluates to 2
 (get @{:a 1 :b 2} :c) # Evaluates to nil
 ```

--- a/doc/content/documentation/control-flow.md
+++ b/doc/content/documentation/control-flow.md
@@ -125,16 +125,16 @@ All expressions are evaluated and if no exception is thrown the value of the las
 ```phel
 (try) # evaluates to nil
 
-(try 
-  (throw (php/new Exception)) 
+(try
+  (throw (php/new Exception))
   (catch Exception e "error")) # evaluates to "error"
 
-(try 
+(try
   (+ 1 1)
   (finally (print "test"))) # Evaluates to 2 and prints "test"
 
-(try 
-  (throw (php/new Exception)) 
+(try
+  (throw (php/new Exception))
   (catch Exception e "error")
   (finally (print "test"))) # evaluates to "error" and prints "test"
 ```

--- a/doc/content/documentation/functions-and-recursion.md
+++ b/doc/content/documentation/functions-and-recursion.md
@@ -56,12 +56,12 @@ Global funcitons can be defined using `defn`.
 Each global function can take an optional doc comment and attribute map.
 
 ```phel
-(defn my-add-function 
+(defn my-add-function
   "adds value a and b"
   [a b]
   (+ a b))
 
-(defn my-private-add-function 
+(defn my-private-add-function
   "adds value a and b"
   @{:private true}
   [a b]
@@ -74,13 +74,13 @@ Similar to `loop`, functions can be made recursive using `recur`.
 
 ```phel
 (fn [x]
-  (if (php/== x 0) 
-    x 
+  (if (php/== x 0)
+    x
     (recur (php/- x 1))))
 
 (defn my-recur-fn [x]
-  (if (php/== x 0) 
-    x 
+  (if (php/== x 0)
+    x
     (recur (php/- x 1))))
 ```
 

--- a/doc/content/documentation/getting-started.md
+++ b/doc/content/documentation/getting-started.md
@@ -9,7 +9,7 @@ Phel requires PHP 7.4 or higher and [Composer](https://getcomposer.org/).
 
 ## Initialize a new project using Composer
 
-The easiest way to get started is by setting up a new Composer project. First create a new directory and initialize a new Composer project 
+The easiest way to get started is by setting up a new Composer project. First create a new directory and initialize a new Composer project
 
 ```bash
 mkdir hello-world
@@ -20,16 +20,16 @@ composer init
 Composer will ask a bunch of questions that can be answered as in the following example:
 
 ```
-Welcome to the Composer config generator  
+Welcome to the Composer config generator
 
 This command will guide you through creating your composer.json config.
 
 Package name (<vendor>/<name>) [jens/phel]: phel/hello-world
-Description []: 
-Author [Your Name <your.name@domain.com>, n to skip]: 
-Minimum Stability []: 
+Description []:
+Author [Your Name <your.name@domain.com>, n to skip]:
+Minimum Stability []:
 Package Type (e.g. library, project, metapackage, composer-plugin) []: project
-License []: 
+License []:
 
 Define your dependencies.
 

--- a/doc/content/documentation/php-interop.md
+++ b/doc/content/documentation/php-interop.md
@@ -65,7 +65,7 @@ Same as above, but for static calls on PHP classes.
 (php/:: DateTimeImmutable ATOM) # Evaluates to "Y-m-d\TH:i:sP"
 
 # Evaluates to a new instance of DateTimeImmutable
-(php/:: DateTimeImmutable (createFromFormat "Y-m-d" "2020-03-22")) 
+(php/:: DateTimeImmutable (createFromFormat "Y-m-d" "2020-03-22"))
 
 ```
 

--- a/doc/sass/_base.scss
+++ b/doc/sass/_base.scss
@@ -17,7 +17,7 @@ hr {
 nav {
     ol,
     ul { padding-left: 0; }
-  
+
     li { list-style: none; }
 }
 

--- a/doc/sass/_code.scss
+++ b/doc/sass/_code.scss
@@ -6,7 +6,7 @@ pre {
 
     border-top: 1px solid $color-base-lines;
     border-bottom: 1px solid $color-base-lines;
-    
+
     overflow-x: auto;
 }
 

--- a/doc/sass/_layout.scss
+++ b/doc/sass/_layout.scss
@@ -88,7 +88,7 @@
                     font-weight: bold;
                 }
             }
-            
+
         }
 
         .documentation__content {

--- a/doc/syntaxes/phel.sublime-syntax
+++ b/doc/syntaxes/phel.sublime-syntax
@@ -88,7 +88,7 @@ contexts:
 
   literal:
     - match: "(true|false|nil)(?=\\s|\\)|\\]|\\})"
-      scope: constant.language.phel   
+      scope: constant.language.phel
 
   number:
     - match: '[-+]?\b(0[bB])[01]+(_[01]+)*\b'
@@ -116,7 +116,7 @@ contexts:
       scope: keyword.control.phel
     - match: "(?<=\\(|\\{|\\[|\\s)(php\\/[^\\s\\#\\(\\)\\{\\}\\[\\]\\'\\\"\\,\\`]+)(?=\\s|\\)|\\]|\\})"
       scope: keyword.other.phel
-    
+
   symbol:
     - match: "[^\\s\\#\\(\\)\\{\\}\\[\\]\\'\\\"\\,\\`]+"
       scope: meta.symbol.phel

--- a/doc/templates/404.html
+++ b/doc/templates/404.html
@@ -12,7 +12,7 @@
 
                 <a href="/">Back to start page</a>
             </div>
-    
+
             {% include "footer.html" %}
         </div>
     </div>

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -35,7 +35,7 @@
   (fn [& xs] (php/new Tuple (php/-> xs (toPhpArray)))))
 
 (def next
-  "```phel\n(next xs)\n```\nReturns the sequence of elements after the first element. If there are no 
+  "```phel\n(next xs)\n```\nReturns the sequence of elements after the first element. If there are no
 elements, returns nil."
   (fn [xs]
     (if (php/== xs nil)
@@ -47,10 +47,10 @@ elements, returns nil."
             (if (php/empty sliced)
               nil
               sliced))
-          (throw (php/new InvalidArgumentException 
+          (throw (php/new InvalidArgumentException
                     (php/. "can not call 'next on " (php/gettype xs)))))))))
 
-(def concat1 
+(def concat1
   @{:private true
     :doc "Concatinates two sequential data structures."}
   (fn [xs ys]
@@ -103,7 +103,7 @@ elements, returns nil."
           _ (php/aset meta :doc docstring)]
       `(def ,name ,meta (fn ,@fdecl)))))
 
-(def defn 
+(def defn
   @{:macro true
     :doc "```phel\n(defn name & fdecl)\n```\nDefine a new global function"}
   (fn [name & fdecl] (apply defn-builder name @{} fdecl)))
@@ -113,7 +113,7 @@ elements, returns nil."
   [name value]
   `(def ,name :private ,value))
 
-(def defmacro 
+(def defmacro
   @{:macro true
     :doc "```phel\n(defmacro name & fdecl)\n```\nDefine a macro"}
   (fn [name & fdecl] (apply defn-builder name @{:macro true} fdecl)))
@@ -125,7 +125,7 @@ elements, returns nil."
 
 (defmacro defmacro-
   "Define a private macro that will not be exported"
-  [name & fdecl] 
+  [name & fdecl]
   (apply defn-builder name @{:macro true :private true} fdecl))
 
 (defmacro declare
@@ -144,19 +144,19 @@ elements, returns nil."
       (defn ,name ,keys (php/new ,class-name-str ,@keys))
       (defn ,is-name [x] (php/is_a x ,class-name-str)))))
 
-(defmacro comment 
+(defmacro comment
   "Ignores the body of the comment"
   [&])
 
-(defn gensym 
+(defn gensym
   "Generates a new unique symbol."
   []
   (php/:: Symbol (gen)))
 
 (defn str
-  "Creates a string by concatenating values together. If no arguments are 
-provided an empty string is returned. Nil and false are represented as empty 
-string. True is represented as 1. Otherwise it tries to call `__toString`. 
+  "Creates a string by concatenating values together. If no arguments are
+provided an empty string is returned. Nil and false are represented as empty
+string. True is represented as 1. Otherwise it tries to call `__toString`.
 This is PHP equalivalent to `$args[0] . $args[1] . $args[2] ...`"
   [& args]
   (if args
@@ -168,23 +168,23 @@ This is PHP equalivalent to `$args[0] . $args[1] . $args[2] ...`"
 # ------------------
 
 (defn tuple-brackets
-  "Creates a new Bracket-Tuple. If no argument is provided, 
+  "Creates a new Bracket-Tuple. If no argument is provided,
 an empty Braket-Tuple is created."
   [& xs]
   (php/new Tuple (php/-> xs (toPhpArray)) true))
 
 (defn array
   "Creates a new Array. If no argument is provided, an empty Array is created."
-  [& xs] 
+  [& xs]
   xs)
 
 (defn table
-  "Creates a new Table. If no argument is provided, an empty Table is created. 
+  "Creates a new Table. If no argument is provided, an empty Table is created.
 The number of parameters must be even."
-  [& xs] 
+  [& xs]
   (php/:: Table (fromKVArray (php/-> xs (toPhpArray)))))
 
-(defn keyword 
+(defn keyword
   "Creates a new Keyword from a given string."
   [x]
   (php/new Keyword x))
@@ -193,7 +193,7 @@ The number of parameters must be even."
 # Basic sequence operations
 # -------------------------
 
-(defn cons 
+(defn cons
   "Prepends `x` to the beginning of `xs`"
   [x xs]
   (if (php/is_array xs)
@@ -204,7 +204,7 @@ The number of parameters must be even."
       (php/-> xs (cons x))
       (if (php/== xs nil)
         @[x]
-        (throw (php/new InvalidArgumentException 
+        (throw (php/new InvalidArgumentException
                   (php/. "can not do cons " (php/print_r x true))))))))
 
 (defn first
@@ -217,13 +217,13 @@ The number of parameters must be even."
   [xs]
   (first (first xs)))
 
-(defn second 
+(defn second
   "Returns the second element of an indexed sequence or nil."
   [xs]
   (php/aget xs 1))
 
-(defn rest 
-  "Returns the sequence of elements after the first element. If there are no 
+(defn rest
+  "Returns the sequence of elements after the first element. If there are no
 elements, returns an empty sequence."
   [xs]
   (if (php/instanceof xs IRest)
@@ -242,8 +242,8 @@ elements, returns an empty sequence."
   [xs]
   (next (next xs)))
 
-(defn count 
-  "Counts the number of elements in a sequence. Can be used on everything that 
+(defn count
+  "Counts the number of elements in a sequence. Can be used on everything that
 implement the PHP Countable interface."
   [xs]
   (if (php/instanceof xs Countable)
@@ -263,7 +263,7 @@ implement the PHP Countable interface."
   [test then & [else]]
   `(if ,test ,else ,then))
 
-(defmacro when 
+(defmacro when
   "Evaluates `test` and if that is logical true, evaluates `body`"
   [test & body]
   `(if ,test (do ,@body)))
@@ -273,7 +273,7 @@ implement the PHP Countable interface."
   [test & body]
   `(if ,test nil (do ,@body)))
 
-(defmacro cond 
+(defmacro cond
   "Takes a set of test/expression pairs. Evaluates each test one at a time.
   If a test returns logically true, the expression is evaluated and return.
   If no test matches a final last expression can be provided that is than
@@ -291,9 +291,9 @@ implement the PHP Countable interface."
 
 (defmacro case
   "Takes an expression `e` and a set of test-content/expression pairs. First
-  evaluates `e` and the then finds the first pair where the test-constant matches 
-  the result of `e`. The associated expression is then evaluated and returned. 
-  If no matches can be found a final last expression can be provided that is 
+  evaluates `e` and the then finds the first pair where the test-constant matches
+  the result of `e`. The associated expression is then evaluated and returned.
+  If no matches can be found a final last expression can be provided that is
   than evaluated and return. Otherwise nil is returned."
   [e & pairs]
   (if (next pairs)
@@ -309,9 +309,9 @@ implement the PHP Countable interface."
 # ----------------
 
 (defmacro or
-  "Evaluates each expression one at a time, from left to right. If a form 
-returns a logical true value, or returns that value and doesn't evaluate any of 
-the other expressions, otherwise it returns the value of the last expression. 
+  "Evaluates each expression one at a time, from left to right. If a form
+returns a logical true value, or returns that value and doesn't evaluate any of
+the other expressions, otherwise it returns the value of the last expression.
 Calling or without arguments, returns nil."
   [& args]
   (case (count args)
@@ -322,9 +322,9 @@ Calling or without arguments, returns nil."
           (if ,v ,v (or ,@(next args)))))))
 
 (defmacro and
-  "Evaluates each expression one at a time, from left to right. If a form 
-returns logical false, and returns that value and doesn't evaluate any of the 
-other expressions, otherwise it returns the value of the last expression. 
+  "Evaluates each expression one at a time, from left to right. If a form
+returns logical false, and returns that value and doesn't evaluate any of the
+other expressions, otherwise it returns the value of the last expression.
 Calling the and function without arguments returns true."
   [& args]
   (case (count args)
@@ -339,7 +339,7 @@ Calling the and function without arguments returns true."
     (php/-> a (identical b))
     (php/=== a b)))
 
-(defn id 
+(defn id
   "Checks if all values are identically. Same as `a === b` in PHP."
   [a & more]
   (case (count more)
@@ -349,7 +349,7 @@ Calling the and function without arguments returns true."
         (recur (first more) (next more))
         false)))
 
-(defn = 
+(defn =
   "Checks if all values are equal. Same as `a == b` in PHP."
   [a & more]
   (case (count more)
@@ -359,13 +359,13 @@ Calling the and function without arguments returns true."
         (recur (first more) (next more))
         false)))
 
-(defn not 
-  "The `not` function returns `true` if the given value is logical false and 
+(defn not
+  "The `not` function returns `true` if the given value is logical false and
 `false` otherwise."
   [x]
   (if x false true))
 
-(defn not= 
+(defn not=
   "Checks if all values are unequal. Same as `a != b` in PHP."
   [a & more]
   (case (count more)
@@ -436,13 +436,13 @@ Calling the and function without arguments returns true."
   [x]
   (= x true))
 
-(defn false? 
+(defn false?
   "Checks if `x` is false. Same as `x === false` in PHP."
   [x]
   (id x false))
 
-(defn compare 
-  "An integer less than, equal to, or greater than zero when `x` is less than, 
+(defn compare
+  "An integer less than, equal to, or greater than zero when `x` is less than,
   equal to, or greater than `y`, respectively."
   [x y]
   (php/<=> x y))
@@ -455,7 +455,7 @@ Calling the and function without arguments returns true."
   "Returns the type of `x`. Following types can be returned:
 
 * `:tuple`
-* `:array` 
+* `:array`
 * `:struct`
 * `:table`
 * `:keyword`
@@ -595,11 +595,11 @@ Calling the and function without arguments returns true."
   (cond
     (php-array? xs) (do (php/apush xs x) xs)
     (php/instanceof xs IPush) (php/-> xs (push x))
-    (throw (php/new InvalidArgumentException 
+    (throw (php/new InvalidArgumentException
               (str "Can not push on type " (type xs))))))
 
 (defn pop
-  "Removes the the last element of the array `xs`. If the array is empty 
+  "Removes the the last element of the array `xs`. If the array is empty
   returns nil."
   [^:reference xs]
   (cond
@@ -616,7 +616,7 @@ Calling the and function without arguments returns true."
     (throw (php/new InvalidArgumentException "Can not remove"))))
 
 (defn get
-  "Get the value mapped to `key` from the datastructure `ds`. 
+  "Get the value mapped to `key` from the datastructure `ds`.
   Returns `opt` or nil if the value can not be found."
   [ds k & [opt]]
   (let [res (php/aget ds k)]
@@ -629,7 +629,7 @@ Calling the and function without arguments returns true."
   [ds key value]
   (do
     (when (php-array? ds)
-      (throw (php/new InvalidArgumentException "Can not call put on pure PHP 
+      (throw (php/new InvalidArgumentException "Can not call put on pure PHP
 arrays. Use (php/aset ds key value)" )))
     (php/aset ds key value)
     ds))
@@ -639,7 +639,7 @@ arrays. Use (php/aset ds key value)" )))
   [ds key]
   (let [x ds]
     (when (php-array? ds)
-      (throw (php/new InvalidArgumentException "Can not call unset on pure PHP 
+      (throw (php/new InvalidArgumentException "Can not call unset on pure PHP
 arrays. Use (php/aunset ds key)" )))
     (php/aunset x key)
     x))
@@ -656,12 +656,12 @@ collection in map"))
              seq xs]
         (if (some? nil? seq)
            res
-           (do 
+           (do
              (push res (apply f (map first seq)))
              (recur res (map next seq)))))))
 
 (defn map-indexed
-  "Applies f to each element in xs. f is a two argument function. The first 
+  "Applies f to each element in xs. f is a two argument function. The first
   argument is index of the element in the sequence and the second element is the
   element itself."
   [f xs]
@@ -729,7 +729,7 @@ collection in map"))
   (let [res @[]]
     (loop [[y & ys] xs]
       (if (and y (pred y))
-        (do 
+        (do
           (push res y)
           (recur ys))
         res))))
@@ -869,7 +869,7 @@ collection in map"))
     (apply array php-array)))
 
 (defn sort-by
-  "Returns a sorted array where the sort order is determined by comparing 
+  "Returns a sorted array where the sort order is determined by comparing
   (keyfn item). If no comperator is supplied compare is used."
   [keyfn xs & [comp]]
   (let [php-array (to-php-array xs)
@@ -936,7 +936,7 @@ collection in map"))
   "Merges multiple tables into first table. If a key appears in more than one
   collection, then later values replace any previous ones."
   [tab & tables]
-  (do 
+  (do
     (foreach [table tables]
       (foreach [k v table]
         (put tab k v)))
@@ -984,7 +984,7 @@ collection in map"))
   (fn [& args]
     (reduce
       |(push $1 (apply $2 args))
-      @[] 
+      @[]
       fs)))
 
 (defn partial [f & args]
@@ -995,9 +995,9 @@ collection in map"))
 # More Sequence operation
 # -----------------------
 
-(defn tree-seq 
+(defn tree-seq
   "Returns an array of the nodes in the tree, via a depth first walk.
-  branch? is a function with one argument that returns true if the given node 
+  branch? is a function with one argument that returns true if the given node
   has children.
   children must be a function with one argument that returns the children of the node.
   root the the root node of the tree."
@@ -1012,8 +1012,8 @@ collection in map"))
             (recur stack)))
         ret))))
 
-(defn flatten 
-  "Takes a nested sequential data structure (tree), and returns their contents 
+(defn flatten
+  "Takes a nested sequential data structure (tree), and returns their contents
   as a single, flat array."
   [xs]
   (filter
@@ -1068,7 +1068,7 @@ collection in map"))
 (defn +
   "Returns the sum of all elements in `xs`. All elements is `xs` must be numbers.
   If `xs` is empty, return 0."
-  [& xs] 
+  [& xs]
   (if (empty? xs)
     0
     (apply php/+ xs)))
@@ -1084,9 +1084,9 @@ collection in map"))
       (reduce2 |(php/- $1 $2) xs)))
 
 (defn *
-  "Returns the product of all elements in `xs`. All elements in `xs` must be 
+  "Returns the product of all elements in `xs`. All elements in `xs` must be
 numbers. If `xs` is empty, return 1."
-  [& xs] 
+  [& xs]
   (case (count xs)
     0 1
     1 (first xs)
@@ -1103,12 +1103,12 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
     2 (php// (first xs) (second xs))
       (reduce2 |(php// $1 $2) xs)))
 
-(defn % 
+(defn %
   "Return the remainder of `dividend` / `divisor`."
   [dividend divisor]
   (php/% dividend divisor))
 
-(defn ** 
+(defn **
   "Return `a` to the power of `x`."
   [a x]
   (php/** a x))
@@ -1135,12 +1135,12 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
 
 (defn zero?
   "Checks if `x` is zero."
-  [x] 
+  [x]
   (= x 0))
 
 (defn one?
   "Checks if `x` is one."
-  [x] 
+  [x]
   (= x 1))
 
 (defn pos?
@@ -1150,7 +1150,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
 
 (defn neg?
   "Checks if `x` is smaller than zero."
-  [x] 
+  [x]
   (< x 0))
 
 (defn nan?
@@ -1216,8 +1216,8 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
                 (loop [res (php/-> printer (print (first xs) false))
                        seq (next xs)]
                   (if seq
-                    (recur 
-                      (str res " " (php/-> printer (print (first seq) false))) 
+                    (recur
+                      (str res " " (php/-> printer (print (first seq) false)))
                       (next seq))
                     res)))))
 
@@ -1225,6 +1225,6 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   (php/print (apply print-str xs)))
 
 (defn println [& xs]
-  (do 
+  (do
     (apply print xs)
     (php/print "\n")))

--- a/src/php/Analyzer.php
+++ b/src/php/Analyzer.php
@@ -1231,7 +1231,7 @@ final class Analyzer
         $ns = $x[1]->getName();
         if (!(preg_match("/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff\\\\]*[a-zA-Z0-9_\x7f-\xff]*$/", $ns))) {
             throw new AnalyzerException(
-                "The namespace is not valid. A valid namespace name starts with a letter or underscore, 
+                "The namespace is not valid. A valid namespace name starts with a letter or underscore,
                 followed by any number of letters, numbers, or underscores. Elements are splitted by a backslash.",
                 $x[1]->getStartLocation(),
                 $x[1]->getEndLocation()

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -81,7 +81,7 @@
 (assert (= [1 2] (cons 1 [2])) "cons tuple")
 (assert (= @[1 2] (cons 1 @[2])) "cons array")
 (assert (= @[1] (cons 1 nil)) "cons nil")
- 
+
 (assert (= 1 (first [1])) "first of tuple")
 (assert (= nil (first [])) "frist of empty tuple")
 (assert (= 1 (first @[1])) "first of array")
@@ -93,7 +93,7 @@
 (assert (= 1 (ffirst [[1]])) "ffirst of nested tuple")
 (assert (= nil (ffirst [1])) "ffirst of tuple")
 (assert (= nil (ffirst nil)) "ffirst of nil")
- 
+
 (assert (= 2 (second [1 2])) "second of tuple")
 (assert (= nil (second [])) "second of empty tuple")
 (assert (= 2 (second @[1 2])) "second of array")
@@ -547,7 +547,7 @@
 (assert (= @[:a :a :a] (repeat 3 :a)) "(repeat 3 :a)")
 (assert (= @[] (repeat 0 :a)) "(repeat 0 :a)")
 
-(assert (= @{1 @["a"] 2 @["as" "aa"] 3 @["asd"] 4 @["asdf" "qwer"]} 
+(assert (= @{1 @["a"] 2 @["as" "aa"] 3 @["asd"] 4 @["asdf" "qwer"]}
            (group-by php/strlen ["a" "as" "asd" "aa" "asdf" "qwer"])) "group-by")
 
 (assert (= @{:a 1 :b 2 :c 3} (zipcoll [:a :b :c] [1 2 3])) "zipcoll")

--- a/tests/php/Fixtures/Let/let-binding.test
+++ b/tests/php/Fixtures/Let/let-binding.test
@@ -1,10 +1,10 @@
 --PHEL--
-(let [a [1 2] 
+(let [a [1 2]
       [b c] [3 4]
       [d e] [5 6 7]
       [f g] [8]
       [h & xs] [1 2 3 4]
-      [h & [i]] [1 2 3 4]] 
+      [h & [i]] [1 2 3 4]]
   (php/+ b c d e f))
 --PHP--
 $a_27 = \Phel\Lang\Tuple::createBracket(1, 2);

--- a/tests/php/Fixtures/Let/loop-destructure.test
+++ b/tests/php/Fixtures/Let/loop-destructure.test
@@ -3,8 +3,8 @@
   (:use \Phel\Lang\Nil))
 
 (loop [[x & xs] [1 2 3 4]
-       sum 0] 
-  (if x 
+       sum 0]
+  (if x
     (if (php/== x nil) sum (recur xs (php/+ sum x)))))
 --PHP--
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "\\test";

--- a/tests/php/Fixtures/Let/loop.test
+++ b/tests/php/Fixtures/Let/loop.test
@@ -1,6 +1,6 @@
 --PHEL--
 (loop [n 10
-       sum 0] 
+       sum 0]
   (if (php/<= n 0) sum (recur (php/- n 1) (php/+ sum n))))
 --PHP--
 $n_1 = 10;

--- a/tests/php/Fixtures/Recur/recur-fn-one-arg.test
+++ b/tests/php/Fixtures/Recur/recur-fn-one-arg.test
@@ -1,7 +1,7 @@
 --PHEL--
 (fn [x]
-  (if (php/== x 0) 
-    x 
+  (if (php/== x 0)
+    x
     (recur (php/- x 1))))
 --PHP--
 new class() extends \Phel\Lang\AFn {

--- a/tests/php/Fixtures/Recur/recur-fn-two-args.test
+++ b/tests/php/Fixtures/Recur/recur-fn-two-args.test
@@ -1,7 +1,7 @@
 --PHEL--
-(fn [x y] 
-  (if (php/== x 0) 
-    x 
+(fn [x y]
+  (if (php/== x 0)
+    x
     (recur (php/- x 1) (php/+ y 1))))
 --PHP--
 new class() extends \Phel\Lang\AFn {

--- a/tests/php/Fixtures/Try/try-catch-finally-expr-throw.test
+++ b/tests/php/Fixtures/Try/try-catch-finally-expr-throw.test
@@ -1,6 +1,6 @@
 --PHEL--
-(def x 
-  (try (php/+ 1 1) 
+(def x
+  (try (php/+ 1 1)
     (catch \Exception e (throw e))
     (finally (php/+ 3 3))))
 --PHP--

--- a/tests/php/Fixtures/Try/try-catch-finally-expr.test
+++ b/tests/php/Fixtures/Try/try-catch-finally-expr.test
@@ -1,6 +1,6 @@
 --PHEL--
-(def x 
-  (try (php/+ 1 1) 
+(def x
+  (try (php/+ 1 1)
     (catch \Exception e (php/+ 2 2))
     (finally (php/+ 3 3))))
 --PHP--

--- a/tests/php/Fixtures/Try/try-catch-finally.test
+++ b/tests/php/Fixtures/Try/try-catch-finally.test
@@ -1,5 +1,5 @@
 --PHEL--
-(try (php/+ 1 1) 
+(try (php/+ 1 1)
   (catch \Exception e (throw e))
   (finally (php/+ 1 1)))
 --PHP--


### PR DESCRIPTION
Some developers (me for instance) have a their editor configured to automatically remove trailing spaces. This PR should improve developer experience and PR readability when using this kind of configuration.