### PR TITLE
Adding docker using PHP:7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run tests to the compiler itself
-        run: composer run-script phpunit
+        run: composer run-script test-compiler
 
       - name: Run tests to the core library
-        run: composer run-script test
+        run: composer run-script test-core

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data
 doc/public
 .phel-repl-history
 .php_cs.cache
+.idea/

--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,18 @@ The rest of this Readme file documents on how to work with the compiler code.
 
 Feel free to ask questions and join discussions on the [Phel Gitter channel](https://gitter.im/phel-lang/community).
 
-## Build the documentation
+
+## Development and contribution
+
+### Your first try!
+
+1. Clone/Fork the project and `cd` inside the repository
+2. `docker-compose up`
+3. `docker exec -ti -u dev phel_lang_php bash`
+4. `composer install`
+5. `composer test-all`
+
+### Build the documentation
 
 The documentation is build with [Zola](https://www.getzola.org/). To build and serve the documentation on a local machine, run:
 
@@ -26,16 +37,17 @@ cd doc
 zola build
 ```
 
-## Test
+### Tests
 
-Phel has two test suites. The first test suite runs a PHPUnit test to test the compiler itself. The second test suite is a simple Phel script to test the core library.
+Phel has two test suites: `test-compiler` & `test-core`:
 
+```bash
+composer test-compiler # it runs a PHPUnit test suite to test the compiler itself.
+composer test-core     # it is a simple Phel script to test the core library.
+composer test-all      # (both: compiler & core)
 ```
-composer phpunit
-composer test
-```
 
-## Run on PHP 8 with JIT
+### Run on PHP 8 with JIT
 
 The JIT compiler in PHP 8 provides more speed for the Phel compiler. To compare the runtime on PHP 7.4 vs PHP 8 the following command can be use.
 

--- a/Readme.md
+++ b/Readme.md
@@ -39,12 +39,14 @@ zola build
 
 ### Tests
 
-Phel has two test suites: `test-compiler` & `test-core`:
+Phel has two test suites. 
+The first test suite runs PHPUnit to test the compiler itself.
+The second test suite runs tests against Phel's core library.
 
 ```bash
-composer test-compiler # it runs a PHPUnit test suite to test the compiler itself.
-composer test-core     # it is a simple Phel script to test the core library.
-composer test-all      # (both: compiler & core)
+composer test-compiler # test the compiler.
+composer test-core # test core library
+composer test-all # runs both script after each other
 ```
 
 ### Run on PHP 8 with JIT

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,12 @@
         }
     },
     "scripts": {
-        "phpunit": "vendor/bin/phpunit",
-        "phpunit:coverage": "vendor/bin/phpunit --coverage-html data/coverage-report",
-        "test": "php tests/phel/test-runner.php"
+        "test-compiler": "vendor/bin/phpunit",
+        "test-compiler:coverage": "vendor/bin/phpunit --coverage-html data/coverage-report",
+        "test-core": "php tests/phel/test-runner.php",
+        "psalm": "vendor/bin/psalm",
+        "test-all": "composer psalm && composer test-compiler && composer test-core",
+        "csfix": "vendor/bin/php-cs-fixer fix"
     },
     "bin": [
         "phel"

--- a/devops/dev/php.dockerfile
+++ b/devops/dev/php.dockerfile
@@ -7,7 +7,5 @@ RUN pecl install -o -f xdebug \
     && docker-php-ext-enable xdebug
 RUN curl https://getcomposer.org/download/1.10.7/composer.phar > /usr/local/bin/composer
 RUN chmod 755 /usr/local/bin/composer
-ENV XDEBUG_CONFIG="idekey=anything-works-here"
-ENV PHP_IDE_CONFIG="serverName=Docker"
 RUN useradd -m dev
 WORKDIR /srv/phel-lang

--- a/devops/dev/php.dockerfile
+++ b/devops/dev/php.dockerfile
@@ -5,7 +5,7 @@ RUN apt-get install -y git
 RUN pecl install -o -f xdebug \
     && rm -rf /tmp/pear \
     && docker-php-ext-enable xdebug
-RUN curl https://getcomposer.org/download/1.10.7/composer.phar > /usr/local/bin/composer
+RUN curl https://getcomposer.org/composer-stable.phar > /usr/local/bin/composer
 RUN chmod 755 /usr/local/bin/composer
 RUN useradd -m dev
 WORKDIR /srv/phel-lang

--- a/devops/dev/php.dockerfile
+++ b/devops/dev/php.dockerfile
@@ -1,0 +1,13 @@
+FROM php:7.4-fpm
+RUN apt-get update -y
+RUN apt-get upgrade -y
+RUN apt-get install -y git
+RUN pecl install -o -f xdebug \
+    && rm -rf /tmp/pear \
+    && docker-php-ext-enable xdebug
+RUN curl https://getcomposer.org/download/1.10.7/composer.phar > /usr/local/bin/composer
+RUN chmod 755 /usr/local/bin/composer
+ENV XDEBUG_CONFIG="idekey=anything-works-here"
+ENV PHP_IDE_CONFIG="serverName=Docker"
+RUN useradd -m dev
+WORKDIR /srv/phel-lang

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+phel_lang_php:
+  build: .
+  dockerfile: devops/dev/php.dockerfile
+  container_name: phel_lang_php
+  hostname: php
+  volumes:
+    - .:/srv/phel-lang:delegated
+    - ~/.ssh:/home/dev/.ssh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,3 @@ phel_lang_php:
   hostname: php
   volumes:
     - .:/srv/phel-lang:delegated
-    - ~/.ssh:/home/dev/.ssh

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
@@ -8,15 +8,22 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         verbose="true">
+         verbose="true"
+         testdox="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
     <testsuites>
-        <testsuite name="unit">
-            <directory suffix="Test.php">tests/</directory>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
+
     <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
+        <whitelist>
+            <directory>src</directory>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
# Description

* Adding docker-compose with docker using `PHP:7.4` for dev env
* Renamed the script names for the tests:
  * `phpunit` to `test-compiler`
  * `test` to `test-core`
* Added `composer psalm` and `composer csfix` to "composer scripts"
* Ignore `.idea/` directory (from PHPStorm)