### PR TITLE
Cleaning Table and Struct classes

### DIFF
--- a/src/php/Lang/Struct.php
+++ b/src/php/Lang/Struct.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 use InvalidArgumentException;
@@ -27,19 +29,19 @@ abstract class Struct extends Table
         }
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->validateOffset($offset);
         parent::offsetSet($offset, $value);
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         $this->validateOffset($offset);
         return parent::offsetExists($offset);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->validateOffset($offset);
         parent::offsetUnset($offset);


### PR DESCRIPTION
# Description

* Declaring [strict types](https://github.com/Chemaclass/php-best-practices/blob/master/technical-skills/strict-types.md).
* Defining type properties.
* Adding return types to functions. 
* Strict conditions when possible.
  * The only one case when it's not possible to define as strict condition is in the `Table::equals($other)` method.
* Removing unnecessary `else` statements due to return early.
  * It also decreases the indentation of the blocks which helps a lot to follow the logic.
* No logic was altered.