### PR TITLE
install zip in dockerfile

### DIFF
--- a/build/php.dockerfile
+++ b/build/php.dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.4-fpm
 RUN apt-get update -y
 RUN apt-get upgrade -y
-RUN apt-get install -y git
+RUN apt-get install -y git zip
 RUN pecl install -o -f xdebug \
     && rm -rf /tmp/pear \
     && docker-php-ext-enable xdebug


### PR DESCRIPTION
In order to improve performances when running `composer install`, I installed zip to allow composer to use _dist_ instead of _sources_.

![image](https://user-images.githubusercontent.com/23403270/84384339-0a497400-ac18-11ea-9d2a-31dc97b907b5.png)
