### PR TITLE
Fix Dockerfile dependencies

### DIFF
--- a/build/php.dockerfile
+++ b/build/php.dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.4-fpm
-RUN apt-get update -y
-RUN apt-get upgrade -y
-RUN apt-get install -y git zip
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y git zip
 RUN pecl install -o -f xdebug \
     && rm -rf /tmp/pear \
     && docker-php-ext-enable xdebug


### PR DESCRIPTION
# Description

When you try to install the project from Docker, for any reason, when it starts with the dependencies'  installation (`apt install -y git zip`), the process is cancelled.

I try some scenarios and for some strange reason if you remove the `RUN` keywords and replaced them by `&&`. With the proposal PR, it works like a charm.

## Scenario:
1. `docker-compose up`

<img width="1440" alt="Screenshot 2020-06-11 at 21 12 26" src="https://user-images.githubusercontent.com/6381924/84432191-c745cb80-ac2c-11ea-9538-352fbeba3aa1.png">
