### PR TITLE
Cleaning GlobalEnvironment class

### DIFF
--- a/src/php/Analyzer.php
+++ b/src/php/Analyzer.php
@@ -1394,7 +1394,7 @@ final class Analyzer
             );
         }
 
-        $this->globalEnvironment->addDefintion($namespace, $name, $meta);
+        $this->globalEnvironment->addDefinition($namespace, $name, $meta);
 
         return new DefNode(
             $nodeEnvironment,

--- a/src/php/Runtime.php
+++ b/src/php/Runtime.php
@@ -190,7 +190,7 @@ class Runtime
                 /** @var Table $meta */
                 $meta = $GLOBALS['__phel_meta'][$ns][$name] ?? new Table();
                 if ($meta[new Keyword('private')] !== true) {
-                    $this->globalEnv->addDefintion(
+                    $this->globalEnv->addDefinition(
                         $ns,
                         new Symbol($name),
                         $GLOBALS['__phel'][$ns][$name]->getMeta()


### PR DESCRIPTION
# Description

* Making the class strict & final
* Rename the method `addDefintion()` to `addDefinition()`.
* Define the type and make properties private (better encapsulation).
* Simplify an `isset()` _L45_
   * It is not necessary to check twice if the key and sub-key exists. [DEMO](http://sandbox.onlinephpfunctions.com/code/11557f70adf59254dde4705685dc6275f067de2d)
* Removing unnecessary `else` statements.
* Split the logic from `addRequireAlias()` into `resolveWithAlias()` & `resolveWithoutAlias()`.
* No logic was altered.