### PR TITLE
Fix keyword? docu

### DIFF
--- a/doc/content/documentation/api.md
+++ b/doc/content/documentation/api.md
@@ -608,7 +608,7 @@ Creates a new Keyword from a given string.
 ```phel
 (keyword? x)
 ```
-Returns true if `x` is a string, false otherwise.
+Returns true if `x` is a keyword, false otherwise.
 
 ## `kvs`
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -522,7 +522,7 @@ Calling the and function without arguments returns true."
   (= (type x) :string))
 
 (defn keyword?
-  "Returns true if `x` is a string, false otherwise."
+  "Returns true if `x` is a keyword, false otherwise."
   [x]
   (= (type x) :keyword))
 


### PR DESCRIPTION
# Description

I just realize that there a typo in the `keyword?` api documentation.

# Changes

- I changed `string` to `keyword` for the docu related with the `keyword?`