### PR TITLE
Improve documentation

### DIFF
--- a/doc/content/_index.md
+++ b/doc/content/_index.md
@@ -49,9 +49,9 @@ The following example gives a short impression on how Phel looks like:
 
 ## Getting started
 
-Phel requires PHP 7.4 or higher and Composer. Read the [Getting Started Guide](/documentation/getting-started) to create your first Phel programm.
+Phel requires PHP 7.4 or higher and Composer. Read the [Getting Started Guide](/documentation/getting-started) to create your first Phel program.
 
 
 ## Status of Development
 
-Phel has not been released yet, but it is fairly complete. In the next weeks or months I will probably find some more edge cases that I will fix before the first offical release. Maybe some of you are willing to test it out and give feedback.
+Phel has not been released yet, but it is fairly complete. In the next weeks or months I will probably find some more edge cases that I will fix before the first official release. Maybe some of you are willing to test it out and give feedback.

--- a/doc/content/blog/functional-programming-in-php.md
+++ b/doc/content/blog/functional-programming-in-php.md
@@ -3,7 +3,7 @@ title = "My attempt on functional programming in PHP"
 template = "blog-entry.html"
 +++
 
-PHP was one of my first languages I learned. Even so, this dates back over 10 years, I still use PHP every day at work. However, in the meantime I also learned a lot of other languages like Java, Clojure, Scala, Python, Javascript and Scheme. By learning all the languages and their concepts, the concept of functional programming always was my favorite and so I tried to make my PHP programming style more functional. In the following article you can read some of the approaches I tried.
+PHP was one of my first languages I learned. Even so, this dates back over 10 years, I still use PHP every day at work. However, in the meantime I also learned a lot of other languages like Java, Clojure, Scala, Python, Javascript and Scheme. By learning all the languages and their concepts, the concept of functional programming always was my favorite and so I tried to make my PHP programming style more functional. In the following article you can read some approaches I tried.
 
 ## Functions as arguments
 
@@ -70,7 +70,7 @@ class MyStaticModule {
 }
 ```
 
-This approach gives us all the flexibiliy in terms of modularity. However, the problem of passing functions as arguments for another function hasn't been solved.
+This approach gives us all the flexibility in terms of modularity. However, the problem of passing functions as arguments for another function hasn't been solved.
 
 ## Trait modules
 
@@ -130,11 +130,11 @@ class MyProgram {
 
 A big disadvantage of this approach is, that we have to resolve all conflicting function names ourself. Not only for public methods but also for private methods. This becomes next to impossible if the program grows.
 
-A combination of the class module approach and the trait module approach would be a good solution to get started with function programming in PHP. However, the trick with the magic method `_get` can not be used for the class module approach, since PHP has no magic method for static properties.
+A combination of the class module approach and the trait module approach would be a good solution to get started with function programming in PHP. However, the trick with the magic method `_get` cannot be used for the class module approach, since PHP has no magic method for static properties.
 
 ## Alternatives
 
-One last alternaitve is to use a language that is functional and compiles to PHP. In recent years, there have been a few attempts on this (e.g. [Haxe](https://haxe.org/) and [Pharen](http://www.pharen.org/)). While Pharen looked very promising, it hasn't seen any commits for a few years now and is still based on PHP 5.
+One last alternative is to use a language that is functional and compiles to PHP. In recent years, there have been a few attempts on this (e.g. [Haxe](https://haxe.org/) and [Pharen](http://www.pharen.org/)). While Pharen looked very promising, it hasn't seen any commits for a few years now and is still based on PHP 5.
 
 ## Introducing Phel
 

--- a/doc/content/documentation/api.md
+++ b/doc/content/documentation/api.md
@@ -223,7 +223,7 @@ Takes an expression `e` and a set of test-content/expression pairs. First
 ```phel
 (comment &)
 ```
-Ignores the body of the comment
+Ignores the body of the comment.
 
 ## `comp`
 
@@ -269,7 +269,7 @@ Takes a set of test/expression pairs. Evaluates each test one at a time.
 ```phel
 (cons x xs)
 ```
-Prepends `x` to the beginning of `xs`
+Prepends `x` to the beginning of `xs`.
 
 ## `count`
 
@@ -295,42 +295,42 @@ Declare a global symbol before it is defined.
 
 ## `def-`
 
-Define a private value that will not be exported
+Define a private value that will not be exported.
 
 ## `defmacro`
 
 ```phel
 (defmacro name & fdecl)
 ```
-Define a macro
+Define a macro.
 
 ## `defmacro-`
 
 ```phel
 (defmacro- name & fdecl)
 ```
-Define a private macro that will not be exported
+Define a private macro that will not be exported.
 
 ## `defn`
 
 ```phel
 (defn name & fdecl)
 ```
-Define a new global function
+Define a new global function.
 
 ## `defn-`
 
 ```phel
 (defn- name & fdecl)
 ```
-Define a private function that will not be exported
+Define a private function that will not be exported.
 
 ## `defstruct`
 
 ```phel
 (defstruct name keys)
 ```
-Define a new struct
+Define a new struct.
 
 ## `distinct`
 
@@ -344,8 +344,8 @@ Returns an array with duplicated values removed in `xs`.
 ```phel
 (dofor head & body)
 ```
-Repeatedly executes body for side-effects with bindings and modifiers as
-  provided by for. Returns nil
+Repeatedly executes body for side effects with bindings and modifiers as
+  provided by for. Returns nil.
 
 ## `drop`
 
@@ -457,8 +457,8 @@ List comprehension. The head of the loop is a tuple that contains a
   After each loop binding additional modifiers can be applied. Modifiers
   have the form `:modifier argument`. The following modifiers are supported:
 
-  * :while breaks the loop if the expression is falsy
-  * :let defines additional bindings
+  * :while breaks the loop if the expression is falsy.
+  * :let defines additional bindings.
   * :when only evaluates the loop body if the condition is true.
 
   The for loops returns a array with all evaluated elements of the body.
@@ -519,11 +519,11 @@ Create a response from a string.
 ```phel
 (create-response-from-table @{:status status :headers headers :body body :version version :reason reason})
 ```
-Creates a response struct from a table. The table can have the following keys
-  * `:status` The HTTP Status (default 200)
-  * `:headers` A table of HTTP Headers (default: empty table)
-  * `:body` The body of the response (default: empty string)
-  * `:version` The HTTP Version (default: 1.1)
+Creates a response struct from a table. The table can have the following keys:
+  * `:status` The HTTP Status (default 200).
+  * `:headers` A table of HTTP Headers (default: empty table).
+  * `:body` The body of the response (default: empty string).
+  * `:version` The HTTP Version (default: 1.1).
   * `:reason` The HTTP status reason. If not provided a common status reason is taken.
 
 ## `http/emit-response`
@@ -538,42 +538,42 @@ Emits the response.
 ```phel
 (files-from-globals & [files])
 ```
-Extracts the files from `$_FILES` and normalizes them to a table of "uploaded-file"
+Extracts the files from `$_FILES` and normalizes them to a table of "uploaded-file".
 
 ## `http/headers-from-server`
 
 ```phel
 (headers-from-server & [server])
 ```
-Extracts all headers from the `$_SERVER` variable
+Extracts all headers from the `$_SERVER` variable.
 
 ## `http/request`
 
 ```phel
 (request method uri headers parsed-body query-params cookie-params server-params uploaded-files version)
 ```
-Creates a new request struct
+Creates a new request struct.
 
 ## `http/request-from-globals`
 
 ```phel
 (request-from-globals & [server])
 ```
-Extracts a request from `$_SERVER`
+Extracts a request from `$_SERVER`.
 
 ## `http/request?`
 
 ```phel
 (request? x)
 ```
-Checks if `x` is a instance of the request struct
+Checks if `x` is a instance of the request struct.
 
 ## `http/response`
 
 ```phel
 (response status headers body version reason)
 ```
-Creates a new response struct
+Creates a new response struct.
 
 ## `http/response?`
 
@@ -587,21 +587,21 @@ Checks if `x` is an instance of the response struct
 ```phel
 (uploaded-file tmp-file size error-status client-filename client-media-type)
 ```
-Creates a new uploaded-file struct
+Creates a new uploaded-file struct.
 
 ## `http/uploaded-file?`
 
 ```phel
 (uploaded-file? x)
 ```
-Checks if `x` is a instance of the uploaded-file struct
+Checks if `x` is a instance of the uploaded-file struct.
 
 ## `http/uri`
 
 ```phel
 (uri scheme userinfo host port path query fragment)
 ```
-Creates a new uri struct
+Creates a new uri struct.
 
 ## `http/uri-from-globals`
 
@@ -615,7 +615,7 @@ Extracts the URI from the `$_SERVER` variable.
 ```phel
 (uri? x)
 ```
-Checks if `x` is a instance of the uri struct
+Checks if `x` is a instance of the uri struct.
 
 ## `id`
 
@@ -707,7 +707,7 @@ Returns a new table where the keys and values are swapped. If table has
 ```phel
 (keys xs)
 ```
-Gets the keys of an associative data structure
+Gets the keys of an associative data structure.
 
 ## `keyword`
 
@@ -795,7 +795,7 @@ Returns the numeric minimum of all numbers.
 ```phel
 (nan? x)
 ```
-Checks if `x` is not a number
+Checks if `x` is not a number.
 
 ## `neg?`
 
@@ -817,7 +817,7 @@ elements, returns nil.
 ```phel
 (nfirst xs)
 ```
-Same as `(next (first xs))`
+Same as `(next (first xs))`.
 
 ## `nil?`
 
@@ -884,7 +884,7 @@ Calling or without arguments, returns nil.
 ```phel
 (pairs xs)
 ```
-Gets the pairs of an associative data structure
+Gets the pairs of an associative data structure.
 
 ## `partial`
 
@@ -912,7 +912,7 @@ Returns the last element of a sequence.
 ```phel
 (php-array-to-table arr)
 ```
-Converts a PHP Array to a tables
+Converts a PHP Array to a tables.
 
 ## `php-array?`
 
@@ -933,7 +933,7 @@ Creates a PHP associative array. An even number of parameters must be provided.
 ```phel
 (php-indexed-array & xs)
 ```
-Creates an PHP indexed array from the given values
+Creates an PHP indexed array from the given values.
 
 ## `php-object?`
 
@@ -984,7 +984,7 @@ Same as print. But instead of writing it to a output stream,
 ```phel
 (println & xs)
 ```
-Same as print followed by a newline
+Same as print followed by a newline.
 
 ## `push`
 
@@ -1019,7 +1019,7 @@ Returns a random number between 0 and 1.
 ```phel
 (rand-int n)
 ```
-Returns a random number between 0 and `n`
+Returns a random number between 0 and `n`.
 
 ## `range`
 
@@ -1071,7 +1071,7 @@ elements, returns an empty sequence.
 ```phel
 (reverse xs)
 ```
-Reverses the order of the elements in the given sequence
+Reverses the order of the elements in the given sequence.
 
 ## `second`
 
@@ -1121,14 +1121,14 @@ Returns a sorted array where the sort order is determined by comparing
 ```phel
 (split-at n xs)
 ```
-Returns a tuple of [(take n coll) (drop n coll)]
+Returns a tuple of [(take n coll) (drop n coll)].
 
 ## `split-with`
 
 ```phel
 (split-with f xs)
 ```
-Returns a tuple of [(take-while pred coll) (drop-while pred coll)]
+Returns a tuple of [(take-while pred coll) (drop-while pred coll)].
 
 ## `str`
 
@@ -1202,7 +1202,7 @@ Returns true if `x` is a table, false otherwise.
 ```phel
 (to-php-array xs)
 ```
-Create a PHP Array from a sequential data structure
+Create a PHP Array from a sequential data structure.
 
 ## `tree-seq`
 
@@ -1312,21 +1312,21 @@ Returns `ds` without `key`.
 ```phel
 (values xs)
 ```
-Gets the values of an associative data structure
+Gets the values of an associative data structure.
 
 ## `when`
 
 ```phel
 (when test & body)
 ```
-Evaluates `test` and if that is logical true, evaluates `body`
+Evaluates `test` and if that is logical true, evaluates `body`.
 
 ## `when-not`
 
 ```phel
 (when-not test & body)
 ```
-Evaluates `test` and if that is logical true, evaluates `body`
+Evaluates `test` and if that is logical true, evaluates `body`.
 
 ## `with-output-buffer`
 
@@ -1347,5 +1347,4 @@ Checks if `x` is zero.
 ```phel
 (zipcoll a b)
 ```
-Creates a table from two sequencial data structures. Return a new table.
-
+Creates a table from two sequential data structures. Return a new table.

--- a/doc/content/documentation/api.md
+++ b/doc/content/documentation/api.md
@@ -59,14 +59,14 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 ```phel
 (< a & more)
 ```
-Check if all given values are in ascending order. Returns a boolean.
+Checks if each argument is is strictly less than the following argument. Returns a boolean.
 
 ## `<=`
 
 ```phel
 (<= a & more)
 ```
-Check if all given values are in a non-descending order. Returns a boolean.
+Checks if each argument is less than or equal to the following argument. Returns a boolean.
 
 ## `=`
 
@@ -80,14 +80,14 @@ Checks if all values are equal. Same as `a == b` in PHP.
 ```phel
 (> a & more)
 ```
-Check if all given values are in descending order. Returns a boolean.
+Checks if each argument is strictly greater than the following argument. Returns a boolean.
 
 ## `>=`
 
 ```phel
 (>= a & more)
 ```
-Check if all given values are in non-ascending order. Returns a boolean.
+Checks if each argument is greater than or equal to the following argument. Returns a boolean.
 
 ## `NAN`
 

--- a/doc/content/documentation/api.md
+++ b/doc/content/documentation/api.md
@@ -35,7 +35,7 @@ Return `a` to the power of `x`.
 ```phel
 (+ & xs)
 ```
-Returns the sum of all elements in `xs`. All elements is `xs` must be numbers.
+Returns the sum of all elements in `xs`. All elements `xs` must be numbers.
   If `xs` is empty, return 0.
 
 ## `-`
@@ -51,7 +51,7 @@ Returns the difference of all elements in `xs`. If `xs` is empty, return 0. If `
 ```phel
 (/ & xs)
 ```
-Returns the nominator divided by all of the denominators. If `xs` is empty,
+Returns the nominator divided by all the denominators. If `xs` is empty,
 returns 1. If `xs` has one value, returns the reciprocal of x.
 
 ## `<`
@@ -96,9 +96,8 @@ Constant for Not a Number (NAN) values.
 ## `__DIR__`
 
 ```phel
-(__DIR__ )
+(__DIR__)
 ```
-
 
 ## `all?`
 
@@ -217,7 +216,7 @@ Takes an expression `e` and a set of test-content/expression pairs. First
   evaluates `e` and the then finds the first pair where the test-constant matches
   the result of `e`. The associated expression is then evaluated and returned.
   If no matches can be found a final last expression can be provided that is
-  than evaluated and return. Otherwise nil is returned.
+  than evaluated and return. Otherwise, nil is returned.
 
 ## `comment`
 
@@ -263,7 +262,7 @@ Concatenates multiple sequential data structures.
 Takes a set of test/expression pairs. Evaluates each test one at a time.
   If a test returns logically true, the expression is evaluated and return.
   If no test matches a final last expression can be provided that is than
-  evaluated and return. Otherwise nil is returned.
+  evaluated and return. Otherwise, nil is returned.
 
 ## `cons`
 
@@ -453,7 +452,7 @@ List comprehension. The head of the loop is a tuple that contains a
   * :range loop over a range by using the range function.
   * :in loops over all values of a collection.
   * :keys loops over all keys/indexes of a collection.
-  * :pairs loops over all key value pairs of a collections.
+  * :pairs loops over all key value pairs of a collection.
 
   After each loop binding additional modifiers can be applied. Modifiers
   have the form `:modifier argument`. The following modifiers are supported:
@@ -491,7 +490,7 @@ Generates a new unique symbol.
 (get ds k & [opt])
 ```
 Get the value mapped to `key` from the datastructure `ds`.
-  Returns `opt` or nil if the value can not be found.
+  Returns `opt` or nil if the value cannot be found.
 
 ## `get-in`
 
@@ -581,7 +580,7 @@ Creates a new response struct
 ```phel
 (response? x)
 ```
-Checks if `x` is a instance of the response struct
+Checks if `x` is an instance of the response struct
 
 ## `http/uploaded-file`
 
@@ -955,7 +954,7 @@ Returns true if `x` is a PHP resource, false otherwise.
 ```phel
 (pop xs)
 ```
-Removes the the last element of the array `xs`. If the array is empty
+Removes the last element of the array `xs`. If the array is empty
   returns nil.
 
 ## `pos?`
@@ -1107,7 +1106,7 @@ Returns true if `(pred x)` is logical true for at least one `x` in `xs`, else fa
 ```phel
 (sort xs & [comp])
 ```
-Returns a sorted array. If no comperator is supplied compare is used.
+Returns a sorted array. If no comparator is supplied compare is used.
 
 ## `sort-by`
 
@@ -1115,7 +1114,7 @@ Returns a sorted array. If no comperator is supplied compare is used.
 (sort-by keyfn xs & [comp])
 ```
 Returns a sorted array where the sort order is determined by comparing
-  (keyfn item). If no comperator is supplied compare is used.
+  (keyfn item). If no comparator is supplied compare is used.
 
 ## `split-at`
 
@@ -1138,8 +1137,8 @@ Returns a tuple of [(take-while pred coll) (drop-while pred coll)]
 ```
 Creates a string by concatenating values together. If no arguments are
 provided an empty string is returned. Nil and false are represented as empty
-string. True is represented as 1. Otherwise it tries to call `__toString`.
-This is PHP equalivalent to `$args[0] . $args[1] . $args[2] ...`
+string. True is represented as 1. Otherwise, it tries to call `__toString`.
+This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`.
 
 ## `string?`
 
@@ -1214,7 +1213,7 @@ Returns an array of the nodes in the tree, via a depth first walk.
   branch? is a function with one argument that returns true if the given node
   has children.
   children must be a function with one argument that returns the children of the node.
-  root the the root node of the tree.
+  root the root node of the tree.
 
 ## `true?`
 

--- a/doc/content/documentation/api.md
+++ b/doc/content/documentation/api.md
@@ -59,7 +59,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x.
 ```phel
 (< a & more)
 ```
-Checks if each argument is is strictly less than the following argument. Returns a boolean.
+Checks if each argument is strictly less than the following argument. Returns a boolean.
 
 ## `<=`
 

--- a/doc/content/documentation/array-table-and-struct.md
+++ b/doc/content/documentation/array-table-and-struct.md
@@ -3,7 +3,7 @@ title = "Array, Table and Struct"
 weight = 9
 +++
 
-Phel has two mutable datastructures. An array is an indexed sequential datastructure and a table is a associative datastructure. While PHP has one single datastructure to represents arrays and hash tables, Phel splits the in two individual datastructures.
+Phel has two mutable datastructures. An array is an indexed sequential datastructure and a table is an associative datastructure. While PHP has one single datastructure to represents arrays and hash tables, Phel splits them in two individual datastructures.
 
 An array can be created using the `@[` reader macro or the `array` function.
 
@@ -21,7 +21,7 @@ An array can be created using the `@[` reader macro or the `array` function.
 
 ## Getting values
 
-Similar to tuples the functions `get`, `first`, `second`, `next` and `rest` can be used to get values of an array.
+Similar to tuples, the functions `get`, `first`, `second`, `next` and `rest` can be used to get values of an array.
 
 ```phel
 (get @[1 2 3] 2) # Evaluates to 3
@@ -50,7 +50,7 @@ The `get` function can also be use on tables.
 
 ## Setting values
 
-To set a value on an array or a table, use the `put` function. If a given index on an array is past the end of the array, the array is first padded with `nil`.
+To set a value on an array or a table, use the `put` function. If the given index is greater than the length of the array, the array is padded with `nil`.
 
 ```phel
 (let [a @[]]
@@ -71,7 +71,7 @@ To remove a single value from an array or table the `unset` function can be used
 (unset @{:a 1 :b 2} :a) # @{:b 2}
 ```
 
-To remove multiple value from arrays, the `remove` and `slice` function can be used. The function `remove` removes the values from the data structures and returns the removed values. The `slice` function on the otherhand, returns a copy of the array with only the `sliced` elements. The original data structure is left untouched.
+To remove multiple values from arrays, the `remove` and `slice` functions can be used. The function `remove` removes the values from the data structures and returns the removed values. The `slice` function on the other hand, returns a copy of the array with only the `sliced` elements. The original data structure is left untouched.
 
 ```phel
 (let [xs @[1 2 3 4]]
@@ -98,23 +98,23 @@ To count the number of element of an array or table, the `count` function can be
 
 ## Array as a Stack
 
-An array can also be used as a stack. Therefore the `push`, `peek` and `pop` functions can be used. The `push` function add a new value to the stack. The `peek` function returns the last element on the stack but does not remove it. The `pop` function returns the last element on the stack and removes it.
+An array can also be used as a stack. Therefore, the `push`, `peek` and `pop` functions can be used. The `push` function add a new value to the stack. The `peek` function returns the last element on the stack but does not remove it. The `pop` function returns the last element on the stack and removes it.
 
 ```phel
 (let [arr @[]]
   (push arr 1) # -> @[1]
   (peek arr) # Evaluates to 1, arr is unchanged
-  (pop arr)) # Evaluates to 1, arr is not empty @[]
+  (pop arr)) # Evaluates to 1, arr is empty @[]
 ```
 
 ## Struct
 
-A struct is a special kind of table. It only supports a predefined number of keys and is associated to a global name. The struct not only defines itsself but also a predicate function.
+A struct is a special kind of table. It only supports a predefined number of keys and is associated to a global name. The struct not only defines itself but also a predicate function.
 
 ```phel
 (defstruct my-struct [a b c]) # Defines the struct
 (let [x (my_struct 1 2 3)] # Create a new struct
-  (my-struct? x) # Evaluates to truc
+  (my-struct? x) # Evaluates to true
   (get x :a) # Evaluates to 1
   (put x :a 12) # Evaluates to (my-struct 12 2 3)
 ```

--- a/doc/content/documentation/basic-types.md
+++ b/doc/content/documentation/basic-types.md
@@ -110,7 +110,7 @@ Arrays are similar to tuples but have a leading `@`.
 @[:a :b :c]
 ```
 
-An Array in Phel is a indexed datastructure. In contrast to PHP arrays, Phel arrays can not be used as Map, HashTable or Dictionary.
+An Array in Phel is an indexed datastructure. In contrast to PHP arrays, Phel arrays cannot be used as Map, HashTable or Dictionary.
 
 ## Tables
 

--- a/doc/content/documentation/control-flow.md
+++ b/doc/content/documentation/control-flow.md
@@ -95,7 +95,7 @@ Internally `recur` is implemented as a PHP while loop and therefore prevents the
 (foreach [value valueExpr] expr*)
 (foreach [key value valueExpr] expr*)
 ```
-The `foreach` special form can be used to iterate over all kind of PHP datastructures. The return value of `foreach` is always `nil`. The `loop` special form should be prefered of the `foreach` special form whenever possible.
+The `foreach` special form can be used to iterate over all kind of PHP datastructures. The return value of `foreach` is always `nil`. The `loop` special form should be preferred of the `foreach` special form whenever possible.
 
 ```
 (foreach [v [1 2 3]]
@@ -122,7 +122,7 @@ in `let` and `:verb` is one of the following keywords:
 * `:range` loop over a range, by using the range function.
 * `:in` loops over all values of a collection.
 * `:keys` loops over all keys/indexes of a collection.
-* `:pairs` loops over all key value pairs of a collections.
+* `:pairs` loops over all key value pairs of a collection.
 
 After each loop binding additional modifiers can be applied. Modifiers
 have the form `:modifier argument`. The following modifiers are supported:

--- a/doc/content/documentation/functions-and-recursion.md
+++ b/doc/content/documentation/functions-and-recursion.md
@@ -14,8 +14,8 @@ Defines a function. A function consists of a list of parameters and a list of ex
 Function also introduce a new lexical scope that is not accessible outside of the function.
 
 ```phel
-(fn []) # Function with no arguments that returns nil.
-(fn [x] x) # The identitiy function
+(fn []) # Function with no arguments that returns nil
+(fn [x] x) # The identity function
 (fn [] 1 2 3) # A function that returns 3
 (fn [a b] (+ a b)) # A function that returns the sum of a and b
 ```
@@ -46,7 +46,7 @@ There is a shorter form to define an anonymous function. This omits the paramete
 (defn docstring? attributes? [params*] expr*)
 ```
 
-Global funcitons can be defined using `defn`.
+Global functions can be defined using `defn`.
 
 ```phel
 (defn my-add-function [a b]
@@ -89,7 +89,7 @@ Similar to `loop`, functions can be made recursive using `recur`.
 ```phel
 (apply f expr*)
 ```
-Calls the function with the given arguments. The last argument must be a list of values, which are passed as seperate arguments, rather than a single list. Apply returns the result of the calling function.
+Calls the function with the given arguments. The last argument must be a list of values, which are passed as separate arguments, rather than a single list. Apply returns the result of the calling function.
 
 ```phel
 (apply + [1 2 3]) # Evaluates to 6
@@ -99,11 +99,11 @@ Calls the function with the given arguments. The last argument must be a list of
 
 ## Passing by reference
 
-Sometimes it is required that a variable should passed to a function by reference. This can be done by applied the `:reference` metadata to the symbol.
+Sometimes it is required that a variable should pass to a function by reference. This can be done by applied the `:reference` metadata to the symbol.
 
 ```phel
 (fn [^:reference my-arr]
   (php/apush my-arr 10))
 ```
 
-Support for references is very limited in Phel. Currently it only works for function arguments (except destructuring).
+Support for references is very limited in Phel. Currently, it only works for function arguments (except destructuring).

--- a/doc/content/documentation/getting-started.md
+++ b/doc/content/documentation/getting-started.md
@@ -9,7 +9,7 @@ Phel requires PHP 7.4 or higher and [Composer](https://getcomposer.org/).
 
 ## Initialize a new project using Composer
 
-The easiest way to get started is by setting up a new Composer project. First create a new directory and initialize a new Composer project
+The easiest way to get started is by setting up a new Composer project. First create a new directory and initialize a new Composer project.
 
 ```bash
 mkdir hello-world
@@ -51,7 +51,7 @@ Would you like to define your dev dependencies (require-dev) interactively [yes]
 Do you confirm generation [yes]? yes
 ```
 
-Next we can require Phel as dependecy of our project.
+Next we can require Phel as dependency of our project.
 
 ```bash
 # Require and install Phel

--- a/doc/content/documentation/global-and-local-bindings.md
+++ b/doc/content/documentation/global-and-local-bindings.md
@@ -8,7 +8,7 @@ weight = 6
 ```phel
 (def name meta? value)
 ```
-This special form binds a value to a global symbol. A definition can not be redefined at a later point.
+This special form binds a value to a global symbol. A definition cannot be redefined at a later point.
 
 ```phel
 (def my-name "phel")
@@ -38,4 +38,4 @@ Creates a new lexical context with variables defined in bindings. Afterwards the
 (let [x 1
       y (+ x 2)]) # Evaluates to nil
 ```
-All variables defined in _bindings_ are immutable and can not be changed.
+All variables defined in _bindings_ are immutable and cannot be changed.

--- a/doc/content/documentation/http-request-and-response.md
+++ b/doc/content/documentation/http-request-and-response.md
@@ -5,7 +5,7 @@ weight = 14
 
 ## HTTP Request
 
-Phel provides a easy method to access the current HTTP request. While in PHP the request is distrubute in different globals variables (`$_GET`, `$_POST`, `$_SERVER`, `$_COOKIES` and `$_FILES`) Phel normalizes them into a single struct. All functions and structs are defined in the `phel\http` module.
+Phel provides an easy method to access the current HTTP request. While in PHP the request is distribute in different globals variables (`$_GET`, `$_POST`, `$_SERVER`, `$_COOKIES` and `$_FILES`) Phel normalizes them into a single struct. All functions and structs are defined in the `phel\http` module.
 
 The request struct is defined like this:
 
@@ -64,7 +64,7 @@ The `phel\http` module also contains a response struct. This struct can be used 
 ])
 ```
 
-To make it easier to create responses. Phel has two helper methods to create a response.
+To make it easier to create responses. Phel has two helpers methods to create a response.
 
 ```phel
 (ns my-namepace

--- a/doc/content/documentation/macros.md
+++ b/doc/content/documentation/macros.md
@@ -3,9 +3,9 @@ title = "Macros"
 weight = 11
 +++
 
-Phel supports macros. Macros are function that take code as input and return transformed code as output. A macro is like a function that is executed at compile time. They are useful to extend the syntax of the language itself.
+Phel supports macros. Macros are functions that take code as input and return transformed code as output. A macro is like a function that is executed at compile time. They are useful to extend the syntax of the language itself.
 
-Phel's core library itself uses macro to define the language. For example `defn` is as marco
+Phel's core library itself uses macro to define the language. For example `defn` is as macro.
 
 ```phel
 (defn add [a b] (+ a b))
@@ -42,7 +42,7 @@ Quote make macros possible, since its helps to distinguish between code and data
 
 The `defmacro` function can be used to create a macro. It takes the same parameters as `defn`.
 
-Together with `quote` and `defmarco` it is now possible to define a custom `defn`, which is called `mydefn`:
+Together with `quote` and `defmarco`, it is now possible to define a custom `defn`, which is called `mydefn`:
 
 ```phel
 (defmacro mydefn [name args & body]
@@ -52,7 +52,7 @@ This macro is very simple at does not support all the feature of `defn`. But it 
 
 ## Quasiquote
 
-For better readability of marcos the `quasiquote` special form is defined. It turns the definion of macros around. Instead of quoting values that should not be evaluated, `quasiquote` marks values that should be evaluates. Every other value is not evaluated. A shorthand for `quasiquote` is the `` ` `` character. Values that should be evaluates are marked with the `unquote` function (shorthand `,`) or `unquote-splicing` function (shorthand `,@`). With quasiquote the `mydefn` macro can be expressed as
+For better readability of marcos the `quasiquote` special form is defined. It turns the definition of macros around. Instead of quoting values that should not be evaluated, `quasiquote` marks values that should be evaluated. Every other value is not evaluated. A shorthand for `quasiquote` is the `` ` `` character. Values that should be evaluated are marked with the `unquote` function (shorthand `,`) or `unquote-splicing` function (shorthand `,@`). With quasiquote the `mydefn` macro can be expressed as
 
 ```phel
 (defmacro mydefn [name args & body]

--- a/doc/content/documentation/namespaces.md
+++ b/doc/content/documentation/namespaces.md
@@ -5,7 +5,7 @@ weight = 12
 
 ## Namespace (ns)
 
-Every Phel file is required to have a namespace. A valid namespace name starts with a letter, followed by any number of letters, numbers, or dashes. Individual parts of the namespace are seperated by the `\` character. The last part of the namespace has to match the name of the file.
+Every Phel file is required to have a namespace. A valid namespace name starts with a letter, followed by any number of letters, numbers, or dashes. Individual parts of the namespace are separated by the `\` character. The last part of the namespace has to match the name of the file.
 
 ```phel
 (ns name imports*)

--- a/doc/content/documentation/numbers-and-arithmetic.md
+++ b/doc/content/documentation/numbers-and-arithmetic.md
@@ -3,7 +3,7 @@ title = "Numbers and Arithmetic"
 weight = 3
 +++
 
-Phel support integer and floating point numbers. Both use the underlying PHP implementation. Integers can be specified in decimal (base 10), hexadecimal (base 16), octal (base 8) and binary (base 2) notation. Binary, octal and hexadecimal formats may contain underscores (`_`) between digits for better readability.
+Phel support integer and floating-point numbers. Both use the underlying PHP implementation. Integers can be specified in decimal (base 10), hexadecimal (base 16), octal (base 8) and binary (base 2) notation. Binary, octal and hexadecimal formats may contain underscores (`_`) between digits for better readability.
 
 ```phel
 1337 # integer
@@ -36,7 +36,7 @@ All arithmetic operators are entered in prefix notation.
 (+ 1 (* 2 2) (/ 10 5) 3 4 (- 5 6)) # Evaluates to 13
 ```
 
-Some operators support zero, one or mutiple arguments.
+Some operators support zero, one or multiple arguments.
 
 ```phel
 (+) # Evaluates to 0
@@ -60,7 +60,7 @@ Some operators support zero, one or mutiple arguments.
 
 Further numeric operations are `%` to compute the remainder of two values and `**` to raise a number to the power. All numeric operations can be found in the API documentation.
 
-Some numeric operations can result in an undefined or unpresentable value. These values are call _Not a Number_ (NaN). Phel represents this values by the constant `NAN`. You can check if a result is NaN by using the `nan?` function.
+Some numeric operations can result in an undefined or unrepresentable value. These values are call _Not a Number_ (NaN). Phel represents this values by the constant `NAN`. You can check if a result is NaN by using the `nan?` function.
 
 ```phel
 (nan? 1) # false

--- a/doc/content/documentation/php-interop.md
+++ b/doc/content/documentation/php-interop.md
@@ -37,7 +37,7 @@ Evaluates `expr` and creates a new PHP class using the arguments. The instance o
 (php/-> property)
 ```
 
-Calls a method or property on a PHP object. Both `methodname` and `property` must be symbols and can not be a evaluated value.
+Calls a method or property on a PHP object. Both `methodname` and `property` must be symbols and cannot be an evaluated value.
 
 ```phel
 (ns my\module
@@ -79,7 +79,7 @@ Equivalent to PHP's `arr[index] ?? null`.
 
 ```phel
 (php/aget ["a" "b" "c"] 0) # Evaluates to "a"
-(php/aget (php/array "a" "b" "c") 1) # Evaluates to "1"
+(php/aget (php/array "a" "b" "c") 1) # Evaluates to "b"
 (php/aget (php/array "a" "b" "c") 5) # Evaluates to nil
 ```
 

--- a/doc/content/documentation/truth-and-boolean-operations.md
+++ b/doc/content/documentation/truth-and-boolean-operations.md
@@ -67,10 +67,10 @@ The function `id` is equivalent to PHP's identity operator (`===`) with support 
 
 Further comparison function are:
 
-* `<=`: Check if all given values are in a non-descending order. Returns a boolean.
-* `<`: Check if all given values are in ascending order. Returns a boolean.
-* `>=`: Check if all given values are in non-ascending order. Returns a boolean.
-* `>`: Check if all given values are in descending order. Returns a boolean.
+* `<=`: Checks if each argument is less than or equal to the following argument. Returns a boolean.
+* `<`: Checks if each argument is is strictly less than the following argument. Returns a boolean.
+* `>=`: Checks if each argument is greater than or equal to the following argument. Returns a boolean.
+* `>`: Checks if each argument is strictly greater than the following argument. Returns a boolean.
 
 ### Logical operation
 

--- a/doc/content/documentation/truth-and-boolean-operations.md
+++ b/doc/content/documentation/truth-and-boolean-operations.md
@@ -5,7 +5,7 @@ weight = 4
 
 For better compatibility with PHP, Phel has the same concept of truthiness and falsiness. The following values evaluate to `false`:
 
-* `false` itsself
+* `false` itself
 * `nil`
 * the numbers _0_, _-0_, _0.0_ and _-0.0_
 * the empty string
@@ -14,7 +14,7 @@ For better compatibility with PHP, Phel has the same concept of truthiness and f
 * a PHP array with zero elements
 * PHP SimpleXML objects created from empty tags
 
-Everythings else evaluates to `true`. The function `truthy?` can be used to check if a value is thruthy. To check for the values `true` and `false` the functions `true?` and `false?` can be used.
+Everything else evaluates to `true`. The function `truthy?` can be used to check if a value is truthy. To check for the values `true` and `false` the functions `true?` and `false?` can be used.
 
 ```phel
 (truthy? false) # Evaluates to false
@@ -35,7 +35,7 @@ Everythings else evaluates to `true`. The function `truthy?` can be used to chec
 
 ## Identity vs Equality
 
-The function `id` returns `true` if two values are identical. Identical is stricter than equality. It first checks if both types are identical and than compares their values. Phel Keywords and Symbol with the same name are always identical. Tuples, Arrays and Tables are only identical if they point to the same reference.
+The function `id` returns `true` if two values are identical. Identical is stricter than equality. It first checks if both types are identical and then compares their values. Phel Keywords and Symbol with the same name are always identical. Tuples, Arrays and Tables are only identical if they point to the same reference.
 
 ```phel
 (id true true) # Evaluates to true

--- a/doc/content/documentation/truth-and-boolean-operations.md
+++ b/doc/content/documentation/truth-and-boolean-operations.md
@@ -68,7 +68,7 @@ The function `id` is equivalent to PHP's identity operator (`===`) with support 
 Further comparison function are:
 
 * `<=`: Checks if each argument is less than or equal to the following argument. Returns a boolean.
-* `<`: Checks if each argument is is strictly less than the following argument. Returns a boolean.
+* `<`: Checks if each argument is strictly less than the following argument. Returns a boolean.
 * `>=`: Checks if each argument is greater than or equal to the following argument. Returns a boolean.
 * `>`: Checks if each argument is strictly greater than the following argument. Returns a boolean.
 

--- a/doc/content/documentation/tuple.md
+++ b/doc/content/documentation/tuple.md
@@ -3,7 +3,7 @@ title = "Tuple"
 weight = 8
 +++
 
-A Tuple is a immutable sequencial data structure. The two most common ways to create a tuple is using the literal form with bracket characters or calling the tuple function directly.
+A Tuple is an immutable sequential data structure. The two most common ways to create a tuple is using the literal form with bracket characters or calling the tuple function directly.
 
 ```phel
 [1 2 3]
@@ -12,7 +12,7 @@ A Tuple is a immutable sequencial data structure. The two most common ways to cr
 
 ## Getting values
 
-There are multiple ways to get a element from a Tuple. The most common one is the `get` function that takes as first element the Tuple and as second element the index of the value that should be returned. Based on `get` there are also `first` and `second`. The `first` function returns the first element of the Tuple and `second` returns the second element of the Tuple.
+There are multiple ways to get an element from a Tuple. The most common one is the `get` function that takes as first element the Tuple and as second element the index of the value that should be returned. Based on `get` there are also `first` and `second`. The `first` function returns the first element of the Tuple and `second` returns the second element of the Tuple.
 
 ```phel
 (get [1 2 3] 2) # Evaluates to 3

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -400,7 +400,7 @@ Calling the and function without arguments returns true."
       (not (apply = a more))))
 
 (defn <
-  "Check if all given values are in ascending order. Returns a boolean."
+  "Checks if each argument is is strictly less than the following argument. Returns a boolean."
   [a & more]
   (case (count more)
     0 true
@@ -410,7 +410,7 @@ Calling the and function without arguments returns true."
         false)))
 
 (defn <=
-  "Check if all given values are in a non-descending order. Returns a boolean."
+  "Checks if each argument is less than or equal to the following argument. Returns a boolean."
   [a & more]
   (case (count more)
     0 true
@@ -420,7 +420,7 @@ Calling the and function without arguments returns true."
         false)))
 
 (defn >
-  "Check if all given values are in descending order. Returns a boolean."
+  "Checks if each argument is strictly greater than the following argument. Returns a boolean."
   [a & more]
   (case (count more)
     0 true
@@ -430,7 +430,7 @@ Calling the and function without arguments returns true."
         false)))
 
 (defn >=
-  "Check if all given values are in non-ascending order. Returns a boolean."
+  "Checks if each argument is greater than or equal to the following argument. Returns a boolean."
   [a & more]
   (case (count more)
     0 true

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -400,7 +400,7 @@ Calling the and function without arguments returns true."
       (not (apply = a more))))
 
 (defn <
-  "Checks if each argument is is strictly less than the following argument. Returns a boolean."
+  "Checks if each argument is strictly less than the following argument. Returns a boolean."
   [a & more]
   (case (count more)
     0 true

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -53,7 +53,7 @@ elements, returns nil."
               nil
               sliced))
           (throw (php/new InvalidArgumentException
-                    (php/. "can not call 'next on " (php/gettype xs)))))))))
+                    (php/. "cannot call 'next on " (php/gettype xs)))))))))
 
 (def concat1
   @{:private true
@@ -110,26 +110,26 @@ elements, returns nil."
 
 (def defn
   @{:macro true
-    :doc "```phel\n(defn name & fdecl)\n```\nDefine a new global function"}
+    :doc "```phel\n(defn name & fdecl)\n```\nDefine a new global function."}
   (fn [name & fdecl] (apply defn-builder name @{} fdecl)))
 
 (def def-
   @{:macro true
-    :doc "Define a private value that will not be exported"}
+    :doc "Define a private value that will not be exported."}
   (fn [name value] `(def ,name @{:private true} ,value)))
 
 (def defmacro
   @{:macro true
-    :doc "```phel\n(defmacro name & fdecl)\n```\nDefine a macro"}
+    :doc "```phel\n(defmacro name & fdecl)\n```\nDefine a macro."}
   (fn [name & fdecl] (apply defn-builder name @{:macro true} fdecl)))
 
 (defmacro defn-
-  "Define a private function that will not be exported"
+  "Define a private function that will not be exported."
   [name & fdecl]
   (apply defn-builder name @{:private true} fdecl))
 
 (defmacro defmacro-
-  "Define a private macro that will not be exported"
+  "Define a private macro that will not be exported."
   [name & fdecl]
   (apply defn-builder name @{:macro true :private true} fdecl))
 
@@ -139,7 +139,7 @@ elements, returns nil."
   `(def ,name nil))
 
 (defmacro defstruct
-  "Define a new struct"
+  "Define a new struct."
   [name keys]
   (let [name-str (php/-> name (getName))
         class-name-str (php/. *ns* "\\" (php/:: Munge (encode name-str)))
@@ -147,10 +147,10 @@ elements, returns nil."
     `(do
       (defstruct* ,name ,keys)
       (defn ,name ,(php/. "Creates a new " name " struct") ,keys (php/new ,class-name-str ,@keys))
-      (defn ,is-name ,(php/. "Checks if `x` is a instance of the " name " struct") [x] (php/is_a x ,class-name-str)))))
+      (defn ,is-name ,(php/. "Checks if `x` is an instance of the " name " struct") [x] (php/is_a x ,class-name-str)))))
 
 (defmacro comment
-  "Ignores the body of the comment"
+  "Ignores the body of the comment."
   [&])
 
 (defn gensym
@@ -165,7 +165,7 @@ elements, returns nil."
   "Creates a string by concatenating values together. If no arguments are
 provided an empty string is returned. Nil and false are represented as empty
 string. True is represented as 1. Otherwise it tries to call `__toString`.
-This is PHP equalivalent to `$args[0] . $args[1] . $args[2] ...`"
+This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`"
   [& args]
   (if args
     (apply php/. args)
@@ -192,7 +192,7 @@ The number of parameters must be even."
   (php/new Keyword x))
 
 (defn php-indexed-array
-  "Creates an PHP indexed array from the given values"
+  "Creates an PHP indexed array from the given values."
   [& xs]
   (apply php/array xs))
 
@@ -220,7 +220,7 @@ The number of parameters must be even."
     (php/== a b)))
 
 (defn cons
-  "Prepends `x` to the beginning of `xs`"
+  "Prepends `x` to the beginning of `xs`."
   [x xs]
   (if (php/is_array xs)
     (do
@@ -231,7 +231,7 @@ The number of parameters must be even."
       (if (php/== xs nil)
         @[x]
         (throw (php/new InvalidArgumentException
-                  (php/. "can not do cons " (php/print_r x true))))))))
+                  (php/. "cannot do cons " (php/print_r x true))))))))
 
 (defn first
   "Returns the first element of an indexed sequence or nil."
@@ -256,10 +256,10 @@ elements, returns an empty sequence."
     (php/-> xs (rest))
     (if (php/is_array xs)
       (php/array_slice xs 1)
-      (throw (php/new InvalidArgumentException "can not do rest")))))
+      (throw (php/new InvalidArgumentException "cannot do rest")))))
 
 (defn nfirst
-  "Same as `(next (first xs))`"
+  "Same as `(next (first xs))`."
   [xs]
   (next (first xs)))
 
@@ -290,12 +290,12 @@ implement the PHP Countable interface."
   `(if ,test ,else ,then))
 
 (defmacro when
-  "Evaluates `test` and if that is logical true, evaluates `body`"
+  "Evaluates `test` and if that is logical true, evaluates `body`."
   [test & body]
   `(if ,test (do ,@body)))
 
 (defmacro when-not
-  "Evaluates `test` and if that is logical true, evaluates `body`"
+  "Evaluates `test` and if that is logical true, evaluates `body`."
   [test & body]
   `(if ,test nil (do ,@body)))
 
@@ -303,7 +303,7 @@ implement the PHP Countable interface."
   "Takes a set of test/expression pairs. Evaluates each test one at a time.
   If a test returns logically true, the expression is evaluated and return.
   If no test matches a final last expression can be provided that is than
-  evaluated and return. Otherwise nil is returned."
+  evaluated and return. Otherwise, nil is returned."
   [& pairs]
   (let [cnt (count pairs)]
     (if (php/== cnt 0)
@@ -320,7 +320,7 @@ implement the PHP Countable interface."
   evaluates `e` and the then finds the first pair where the test-constant matches
   the result of `e`. The associated expression is then evaluated and returned.
   If no matches can be found a final last expression can be provided that is
-  than evaluated and return. Otherwise nil is returned."
+  than evaluated and return. Otherwise, nil is returned."
   [e & pairs]
   (if (next pairs)
     (let [v (gensym)]
@@ -526,7 +526,7 @@ Calling the and function without arguments returns true."
   (= (type x) :float))
 
 (defn int?
-  "Returns true if `x` is a integer number, false otherwise."
+  "Returns true if `x` is an integer number, false otherwise."
   [x]
   (= (type x) :int))
 
@@ -633,7 +633,7 @@ Calling the and function without arguments returns true."
               (str "Can not push on type " (type xs))))))
 
 (defn pop
-  "Removes the the last element of the array `xs`. If the array is empty
+  "Removes the last element of the array `xs`. If the array is empty
   returns nil."
   [^:reference xs]
   (cond
@@ -651,7 +651,7 @@ Calling the and function without arguments returns true."
 
 (defn get
   "Get the value mapped to `key` from the datastructure `ds`.
-  Returns `opt` or nil if the value can not be found."
+  Returns `opt` or nil if the value cannot be found."
   [ds k & [opt]]
   (let [res (php/aget ds k)]
     (if (nil? res)
@@ -743,13 +743,13 @@ arrays. Use (php/aunset ds key)" )))
   * :range loop over a range by using the range function.
   * :in loops over all values of a collection.
   * :keys loops over all keys/indexes of a collection.
-  * :pairs loops over all key value pairs of a collections.
+  * :pairs loops over all key value pairs of a collection.
 
   After each loop binding additional modifiers can be applied. Modifiers
   have the form `:modifier argument`. The following modifiers are supported:
 
-  * :while breaks the loop if the expression is falsy
-  * :let defines additional bindings
+  * :while breaks the loop if the expression is falsy.
+  * :let defines additional bindings.
   * :when only evaluates the loop body if the condition is true.
 
   The for loops returns a array with all evaluated elements of the body."
@@ -761,8 +761,8 @@ arrays. Use (php/aunset ds key)" )))
       ,res-sym)))
 
 (defmacro dofor
-  "Repeatedly executes body for side-effects with bindings and modifiers as
-  provided by for. Returns nil"
+  "Repeatedly executes body for side effects with bindings and modifiers as
+  provided by for. Returns nil."
   [head & body]
   (for-builder `(do ,@body) head 0))
 
@@ -892,7 +892,7 @@ collection in map"))
     ret))
 
 (defn reverse
-  "Reverses the order of the elements in the given sequence"
+  "Reverses the order of the elements in the given sequence."
   [xs]
   (let [ret @[]]
     (dofor [i :range [(php/- (count xs) 1) -1 -1]]
@@ -926,17 +926,17 @@ collection in map"))
     res))
 
 (defn keys
-  "Gets the keys of an associative data structure"
+  "Gets the keys of an associative data structure."
   [xs]
   (for [k :keys xs] k))
 
 (defn values
-  "Gets the values of an associative data structure"
+  "Gets the values of an associative data structure."
   [xs]
   (for [x :in xs] x))
 
 (defn pairs
-  "Gets the pairs of an associative data structure"
+  "Gets the pairs of an associative data structure."
   [xs]
   (for [p :pairs xs] p))
 
@@ -950,12 +950,12 @@ collection in map"))
     res))
 
 (defn to-php-array
-  "Create a PHP Array from a sequential data structure"
+  "Create a PHP Array from a sequential data structure."
   [xs]
   (apply php/array xs))
 
 (defn php-array-to-table
-  "Converts a PHP Array to a tables"
+  "Converts a PHP Array to a tables."
   [arr]
   (let [res @{}]
     (foreach [k v arr]
@@ -963,7 +963,7 @@ collection in map"))
     res))
 
 (defn sort
-  "Returns a sorted array. If no comperator is supplied compare is used."
+  "Returns a sorted array. If no comparator is supplied compare is used."
   [xs & [comp]]
   (let [php-array (to-php-array xs)]
     (php/usort php-array (or comp compare))
@@ -971,7 +971,7 @@ collection in map"))
 
 (defn sort-by
   "Returns a sorted array where the sort order is determined by comparing
-  (keyfn item). If no comperator is supplied compare is used."
+  (keyfn item). If no comparator is supplied compare is used."
   [keyfn xs & [comp]]
   (let [php-array (to-php-array xs)
         cmp (or comp compare)]
@@ -1029,12 +1029,12 @@ collection in map"))
   (zipcoll (values table) (keys table)))
 
 (defn split-at
-  "Returns a tuple of [(take n coll) (drop n coll)]"
+  "Returns a tuple of [(take n coll) (drop n coll)]."
   [n xs]
   [(take n xs) (drop n xs)])
 
 (defn split-with
-  "Returns a tuple of [(take-while pred coll) (drop-while pred coll)]"
+  "Returns a tuple of [(take-while pred coll) (drop-while pred coll)]."
   [f xs]
   [(take-while f xs) (drop-while f xs)])
 
@@ -1085,7 +1085,7 @@ collection in map"))
   branch? is a function with one argument that returns true if the given node
   has children.
   children must be a function with one argument that returns the children of the node.
-  root the the root node of the tree."
+  root the root node of the tree."
   [branch? children root]
   (let [ret @[]]
     (loop [stack @[root]]
@@ -1151,7 +1151,7 @@ collection in map"))
   php/NAN)
 
 (defn +
-  "Returns the sum of all elements in `xs`. All elements is `xs` must be numbers.
+  "Returns the sum of all elements in `xs`. All elements `xs` must be numbers.
   If `xs` is empty, return 0."
   [& xs]
   (if (empty? xs)
@@ -1179,7 +1179,7 @@ numbers. If `xs` is empty, return 1."
       (reduce2 |(php/* $1 $2) xs)))
 
 (defn /
-  "Returns the nominator divided by all of the denominators. If `xs` is empty,
+  "Returns the nominator divided by all the denominators. If `xs` is empty,
 returns 1. If `xs` has one value, returns the reciprocal of x."
   [& xs]
   (case (count xs)
@@ -1239,7 +1239,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   (< x 0))
 
 (defn nan?
-  "Checks if `x` is not a number"
+  "Checks if `x` is not a number."
   [x]
   (php/is_nan x))
 
@@ -1249,7 +1249,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   (/ (php/random_int 0 php/PHP_INT_MAX) php/PHP_INT_MAX))
 
 (defn rand-int
-  "Returns a random number between 0 and `n`"
+  "Returns a random number between 0 and `n`."
   [n]
   (php/random_int 0 n))
 
@@ -1315,7 +1315,7 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
     nil))
 
 (defn println
-  "Same as print followed by a newline"
+  "Same as print followed by a newline."
   [& xs]
   (do
     (apply print xs)

--- a/tests/php/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Fixtures/Ns/munge-ns.test
@@ -45,5 +45,5 @@ $GLOBALS["__phel"]["hello_world"]["abc?"] = new class() extends \Phel\Lang\AFn {
   }
 };
 $GLOBALS["__phel_meta"]["hello_world"]["abc?"] = \Phel\Lang\Table::fromKVs(
-  new \Phel\Lang\Keyword("doc"), "```phel\n(abc? x)\n```\nChecks if `x` is a instance of the abc struct"
+  new \Phel\Lang\Keyword("doc"), "```phel\n(abc? x)\n```\nChecks if `x` is an instance of the abc struct"
 );


### PR DESCRIPTION
# Description

Fix typo errors from the documentation.

# Notorious Changes

- Replace `can not` by `cannot` in several places.
- Replace some `a` by `an` when the next word starts by vocal.
- Fix typo words such as `programm` or `offical` by `program` or `official` and so on.
- Add a final dot at the end of each phrase in `documentation/api.md` file.
- Replace `(__DIR__ )` by `(__DIR__)` in `api.md` (line 99).
- Add a comma after `Otherwise` adverb.
- Fix some agreement errors (sing + plural).
- Update `phel/core.phel` file with `api` fixes..
- Minor changes.

Edit: Once it is merged, we can close the issue #49 