### PR TITLE
Cleaning reader and compiler

### DIFF
--- a/src/php/Lexer.php
+++ b/src/php/Lexer.php
@@ -1,33 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel;
 
 use Exception;
 use Generator;
 use Phel\Lang\SourceLocation;
 
-class Lexer
+final class Lexer
 {
-
-    /**
-     * @var int
-     */
-    private $cursor = 0;
-
-    /**
-     * @var int
-     */
-    private $line = 1;
-
-    /**
-     * @var int
-     */
-    private $column = 1;
-
-    /**
-     * @var string[]
-     */
-    private $regexps = [
+    private const REGEXPS = [
         "([\n \t\r]+)", // Whitespace (index: 2)
         "(\#[^\n]*)", // Comment (index: 3)
         "(,@)", // unquote-splicing (index: 4)
@@ -48,14 +31,14 @@ class Lexer
         "([^\(\)\[\]\{\}',`@ \n\r\t\#]+)" // Atom (index: 19)
     ];
 
-    /**
-     * @var string
-     */
-    private $combinedRegex;
+    private int $cursor = 0;
+    private int $line = 1;
+    private int $column = 1;
+    private string $combinedRegex;
 
     public function __construct()
     {
-        $this->combinedRegex = "/(?:" . implode("|", $this->regexps) . ")/mA";
+        $this->combinedRegex = "/(?:" . implode("|", self::REGEXPS) . ")/mA";
     }
 
     public function lexString(string $code, string $source = 'string'): Generator

--- a/src/php/Reader.php
+++ b/src/php/Reader.php
@@ -79,7 +79,7 @@ final class Reader
     }
 
     /**
-     * @return Phel|null|string|scalar
+     * @return Phel|null|scalar
      */
     public function readExpression(Generator $tokenStream)
     {

--- a/src/php/Reader.php
+++ b/src/php/Reader.php
@@ -111,7 +111,7 @@ final class Reader
                     return $this->readList($tokenStream, Token::T_CLOSE_PARENTHESIS);
 
                 case Token::T_OPEN_BRACKET:
-                    return $this->readList($tokenStream, Token::T_CLOSE_BRACKET, true);
+                    return $this->readList($tokenStream, Token::T_CLOSE_BRACKET, $isUsingBrackets = true);
 
                 case Token::T_OPEN_BRACE:
                     throw $this->buildReaderException('Expected token: {');
@@ -193,7 +193,7 @@ final class Reader
     /**
      * @return Phel|scalar|null
      */
-    protected function readQuasiquote(Generator $tokenStream)
+    private function readQuasiquote(Generator $tokenStream)
     {
         $startLocation = $tokenStream->current()->getStartLocation();
         $tokenStream->next();
@@ -210,7 +210,7 @@ final class Reader
         return $result;
     }
 
-    protected function readMeta(Generator $tokenStream)
+    private function readMeta(Generator $tokenStream)
     {
         $tokenStream->next();
 
@@ -239,7 +239,7 @@ final class Reader
         return $object;
     }
 
-    protected function readWrap(Generator $tokenStream, string $wrapFn): Tuple
+    private function readWrap(Generator $tokenStream, string $wrapFn): Tuple
     {
         $startLocation = $tokenStream->current()->getStartLocation();
         $tokenStream->next();
@@ -258,7 +258,7 @@ final class Reader
     /**
      * @return string|null|boolean|float|int|Phel
      */
-    protected function readExpressionHard(Generator $tokenStream, string $errorMessage)
+    private function readExpressionHard(Generator $tokenStream, string $errorMessage)
     {
         $result = $this->readExpression($tokenStream);
         if (is_null($result)) {
@@ -268,7 +268,7 @@ final class Reader
         return $result;
     }
 
-    protected function readList(Generator $tokenStream, int $endTokenType, bool $isUsingBrackets = false): Tuple
+    private function readList(Generator $tokenStream, int $endTokenType, bool $isUsingBrackets = false): Tuple
     {
         $acc = [];
         $startLocation = $tokenStream->current()->getStartLocation();
@@ -309,7 +309,7 @@ final class Reader
      *
      * @return boolean|null|Keyword|Symbol|string|int|float
      */
-    protected function parseAtom(Token $token)
+    private function parseAtom(Token $token)
     {
         $word = $token->getCode();
 
@@ -356,7 +356,7 @@ final class Reader
         return $this->readSymbol($word);
     }
 
-    protected function readSymbol($word)
+    private function readSymbol($word)
     {
         if (is_array($this->fnArgs)) {
             // Special case: We read an anonymous function
@@ -390,7 +390,7 @@ final class Reader
         return new Symbol($word);
     }
 
-    protected function parseEscapedString(string $str): string
+    private function parseEscapedString(string $str): string
     {
         $str = str_replace('\\"', '"', $str);
 
@@ -419,7 +419,7 @@ final class Reader
         );
     }
 
-    protected function codePointToUtf8(int $num): string
+    private function codePointToUtf8(int $num): string
     {
         if ($num <= 0x7F) {
             return chr($num);

--- a/src/php/Reader.php
+++ b/src/php/Reader.php
@@ -180,14 +180,14 @@ final class Reader
                     return Tuple::create(new Symbol('fn'), new Tuple($params, true), $body);
 
                 case Token::T_EOF:
-                    throw $this->buildReaderException("Unterminatend list");
+                    throw $this->buildReaderException("Unterminated list");
 
                 default:
                     throw $this->buildReaderException("Unhandled syntax token: " . $token->getCode());
             }
         }
 
-        throw $this->buildReaderException("Unterminatend list");
+        throw $this->buildReaderException("Unterminated list");
     }
 
     /**
@@ -199,8 +199,7 @@ final class Reader
         $tokenStream->next();
 
         $expression = $this->readExpressionHard($tokenStream, "missing expression");
-        $q = new Quasiquote();
-        $result = $q->quasiquote($expression);
+        $result = (new Quasiquote())->quasiquote($expression);
 
         if ($result instanceof Phel) {
             $endLocation = $tokenStream->current()->getEndLocation();

--- a/src/php/Runtime.php
+++ b/src/php/Runtime.php
@@ -194,8 +194,8 @@ class Runtime
     protected function loadFile(string $filename, string $ns): bool
     {
         $globalEnv = $this->globalEnv;
-        $compiler = new Compiler();
-        $code = $compiler->compileFile($filename, $globalEnv);
+        $compiler = new Compiler($globalEnv);
+        $code = $compiler->compileFile($filename);
 
         $cacheFilePath = $this->getCachedFilePath($filename, $ns);
         if ($cacheFilePath) {

--- a/src/php/Token.php
+++ b/src/php/Token.php
@@ -26,6 +26,7 @@ final class Token
     public const T_FN = 17;
     public const T_STRING = 18;
     public const T_ATOM = 19;
+    public const T_COMMA = 20;
     public const T_EOF = 100;
 
     private string $code;

--- a/src/php/Token.php
+++ b/src/php/Token.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Phel;
 
 use Phel\Lang\SourceLocation;
 
-class Token
+final class Token
 {
     public const T_WHITESPACE = 2;
     public const T_COMMENT = 3;
@@ -25,29 +26,12 @@ class Token
     public const T_FN = 17;
     public const T_STRING = 18;
     public const T_ATOM = 19;
-
-
     public const T_EOF = 100;
 
-    /**
-     * @var string
-     */
-    private $code;
-
-    /**
-     * @var int
-     */
-    private $type;
-
-    /**
-     * @var SourceLocation
-     */
-    private $startLocation;
-
-    /**
-     * @var SourceLocation
-     */
-    private $endLocation;
+    private string $code;
+    private int $type;
+    private SourceLocation $startLocation;
+    private SourceLocation $endLocation;
 
     public function __construct(int $type, string $code, SourceLocation $startLocation, SourceLocation $endLocation)
     {

--- a/tests/php/LexerTest.php
+++ b/tests/php/LexerTest.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel;
 
 use Phel\Lang\SourceLocation;
 use PHPUnit\Framework\TestCase;
 
-class LexerTest extends TestCase
+final class LexerTest extends TestCase
 {
-    public function testReadCommentWithoutText()
+    public function testReadCommentWithoutText(): void
     {
         $this->assertEquals(
             [
@@ -18,7 +20,7 @@ class LexerTest extends TestCase
         );
     }
 
-    public function testReadCommentWithoutNewLine()
+    public function testReadCommentWithoutNewLine(): void
     {
         $this->assertEquals(
             [
@@ -29,7 +31,7 @@ class LexerTest extends TestCase
         );
     }
 
-    public function testReadCommentWithNewLine()
+    public function testReadCommentWithNewLine(): void
     {
         $this->assertEquals(
             [
@@ -42,7 +44,7 @@ class LexerTest extends TestCase
         );
     }
 
-    public function testReadSingleSyntaxChar()
+    public function testReadSingleSyntaxChar(): void
     {
         $this->assertEquals(
             [
@@ -53,7 +55,7 @@ class LexerTest extends TestCase
         );
     }
 
-    public function testReadEmptyTuple()
+    public function testReadEmptyTuple(): void
     {
         $this->assertEquals(
             [
@@ -65,7 +67,7 @@ class LexerTest extends TestCase
         );
     }
 
-    public function testReadWord()
+    public function testReadWord(): void
     {
         $this->assertEquals(
             [
@@ -76,7 +78,7 @@ class LexerTest extends TestCase
         );
     }
 
-    public function testReadNumber()
+    public function testReadNumber(): void
     {
         $this->assertEquals(
             [
@@ -87,7 +89,7 @@ class LexerTest extends TestCase
         );
     }
 
-    public function testReadEmptyString()
+    public function testReadEmptyString(): void
     {
         $this->assertEquals(
             [
@@ -98,7 +100,7 @@ class LexerTest extends TestCase
         );
     }
 
-    public function testReadString()
+    public function testReadString(): void
     {
         $this->assertEquals(
             [
@@ -109,7 +111,7 @@ class LexerTest extends TestCase
         );
     }
 
-    public function testReadEscapedString()
+    public function testReadEscapedString(): void
     {
         $this->assertEquals(
             [
@@ -120,7 +122,7 @@ class LexerTest extends TestCase
         );
     }
 
-    public function testReadTuple()
+    public function testReadTuple(): void
     {
         $this->assertEquals(
             [
@@ -135,7 +137,7 @@ class LexerTest extends TestCase
         );
     }
 
-    private function lex($string)
+    private function lex(string $string): array
     {
         $lexer = new Lexer();
         return iterator_to_array($lexer->lexString($string, 'string'));


### PR DESCRIPTION
# Description

I refactored some classes related to the Reader and Compiler without altering its functionality.

# Changes

- Declared classes as [strict](https://github.com/Chemaclass/php-best-practices/blob/master/technical-skills/strict-types.md) and [final](https://medium.com/@chemaclass/final-classes-in-php-9174e3e2747e).
- Removing unnecessary `else` statements due to return early.
- No logic was altered.
- `Quasiquote`
  - I rearranged the class methods: moving the private after the public one.
