### PR TITLE
Splitting analyze() in two methods

### DIFF
--- a/src/php/Analyzer.php
+++ b/src/php/Analyzer.php
@@ -34,6 +34,12 @@ final class Analyzer
     }
 
     /** @param Phel|scalar|null $x */
+    public function analyzeInEmptyEnv($x): Node
+    {
+        return $this->analyze($x, NodeEnvironment::empty());
+    }
+
+    /** @param Phel|scalar|null $x */
     public function analyze($x, NodeEnvironment $env): Node
     {
         if ($this->isLiteral($x)) {

--- a/src/php/Analyzer.php
+++ b/src/php/Analyzer.php
@@ -34,12 +34,8 @@ final class Analyzer
     }
 
     /** @param Phel|scalar|null $x */
-    public function analyze($x, ?NodeEnvironment $env = null): Node
+    public function analyze($x, NodeEnvironment $env): Node
     {
-        if (null === $env) {
-            $env = NodeEnvironment::empty();
-        }
-
         if ($this->isLiteral($x)) {
             return (new AnalyzeLiteral())($x, $env);
         }

--- a/src/php/Compiler.php
+++ b/src/php/Compiler.php
@@ -42,7 +42,7 @@ final class Compiler
                 }
 
                 try {
-                    $nodes = $this->analyzer->analyze($readerResult->getAst());
+                    $nodes = $this->analyzer->analyze($readerResult->getAst(), NodeEnvironment::empty());
                 } catch (AnalyzerException $e) {
                     throw new CompilerException($e, $readerResult->getCodeSnippet());
                 }

--- a/src/php/Compiler.php
+++ b/src/php/Compiler.php
@@ -42,7 +42,7 @@ final class Compiler
                 }
 
                 try {
-                    $nodes = $this->analyzer->analyze($readerResult->getAst(), NodeEnvironment::empty());
+                    $nodes = $this->analyzer->analyzeInEmptyEnv($readerResult->getAst());
                 } catch (AnalyzerException $e) {
                     throw new CompilerException($e, $readerResult->getCodeSnippet());
                 }

--- a/tests/php/IntegrationTest.php
+++ b/tests/php/IntegrationTest.php
@@ -46,7 +46,9 @@ class IntegrationTest extends TestCase
                 break;
             }
 
-            $compiledCode[] = $emitter->emitAndEval($analyzer->analyze($readAst->getAst()));
+            $compiledCode[] = $emitter->emitAndEval(
+                $analyzer->analyze($readAst->getAst(), NodeEnvironment::empty()),
+            );
         }
         $compiledCode = trim(implode("", $compiledCode));
         $this->assertEquals($generatedCode, $compiledCode, "in " . $filename);

--- a/tests/php/IntegrationTest.php
+++ b/tests/php/IntegrationTest.php
@@ -47,7 +47,7 @@ class IntegrationTest extends TestCase
             }
 
             $compiledCode[] = $emitter->emitAndEval(
-                $analyzer->analyze($readAst->getAst(), NodeEnvironment::empty()),
+                $analyzer->analyzeInEmptyEnv($readAst->getAst())
             );
         }
         $compiledCode = trim(implode("", $compiledCode));


### PR DESCRIPTION
# Description

I created another function in `Analyzer` in order to make more strait forward the intention of its public methods. 

```php
public function analyzeInEmptyEnv($x): Node
{
    return $this->analyze($x, NodeEnvironment::empty());
}

public function analyze($x, NodeEnvironment $env): Node
{
    if ($this->isLiteral($x)) {
        return (new AnalyzeLiteral())($x, $env);
    }
// ...
```
# Changes

- The method `analyze($x, NodeEnvironment $env)` has two mandatory parameter. The `$env` is mandatory now.
- I created `analyzeInEmptyEnv($x)` which receives only one argument and "there is no env" (`NodeEnvironment::empty()`).

This way we get rid of the optional second argument and therefore the `if` condition:
```php
if (null === $env) {
    $env = NodeEnvironment::empty();
}
```