### PR TITLE
Implement Sets

### DIFF
--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -690,28 +690,6 @@ arrays. Use (php/aunset ds key)" )))
     (php/aunset x key)
     x))
 
-(declare reduce)
-
-(defn union
-  "Union multiple sets into a new one"
-  [& sets]
-  (reduce concat (set) sets))
-
-(defn intersection
-  "Intersect multiple sets into a new one"
-  [& sets]
-  (reduce (fn [acc s] (php/-> acc (intersection s))) (union (first sets)) (rest sets)))
-
-(defn difference
-  "Difference between multiple sets into a new one"
-  [& sets]
-  (reduce (fn [acc s] (php/-> acc (difference s))) (union (first sets)) (rest sets)))
-
-(defn symmetricDifference
-  "Symmetric difference between multiple sets into a new one"
-  [& sets]
-  (reduce (fn [acc s] (union (difference acc s) (difference s acc))) (union (first sets)) (rest sets)))
-
 # --------
 # For loop
 # --------
@@ -1080,6 +1058,32 @@ collection in map"))
           (if (>= (count b) n)
             (recur b)
             res))))))
+
+
+# -------------
+# Set operation
+# -------------
+
+(defn union
+  "Union multiple sets into a new one"
+  [& sets]
+  (reduce concat (set) sets))
+
+(defn intersection
+  "Intersect multiple sets into a new one"
+  [set & sets]
+  (reduce |(php/-> $1 (intersection $2)) set sets))
+
+(defn difference
+  "Difference between multiple sets into a new one"
+  [set & sets]
+  (reduce |(php/-> $1 (difference $2)) set sets))
+
+(defn symmetric-difference
+  "Symmetric difference between multiple sets into a new one"
+  [set & sets]
+  (reduce |(union (difference $1 $2) (difference $2 $1)) set sets))
+
 
 # ------------------
 # Function operation

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -710,7 +710,7 @@ arrays. Use (php/aunset ds key)" )))
 (defn symmetricDifference
   "Symmetric difference between multiple sets into a new one"
   [& sets]
-  (reduce (fn [acc s] (php/-> acc (symmetricDifference s))) (union (first sets)) (rest sets)))
+  (reduce (fn [acc s] (union (difference acc s) (difference s acc))) (union (first sets)) (rest sets)))
 
 # --------
 # For loop

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -690,33 +690,27 @@ arrays. Use (php/aunset ds key)" )))
     (php/aunset x key)
     x))
 
+(declare reduce)
+
 (defn union
-  "Union multiple sets into a new set"
+  "Union multiple sets into a new one"
   [& sets]
-  (let (s (set))
-    (apply concat s sets)))
+  (reduce concat (set) sets))
 
 (defn intersection
-  "Intersect multiple sets into one"
-  [s & sets]
-  (foreach [se sets]
-    (php/-> s (intersection se)))
-  s)
-
-(defn difference-into
-  "Difference between multiple sets into one"
-  [s & sets]
-  (foreach [se sets]
-    (php/-> s (difference se)))
-  s)
+  "Intersect multiple sets into a new one"
+  [& sets]
+  (reduce (fn [acc s] (php/-> acc (intersection s))) (union (first sets)) (rest sets)))
 
 (defn difference
-  "Difference between multiple sets"
+  "Difference between multiple sets into a new one"
   [& sets]
-  (if (= (count sets) 0)
-    (set)
-    (apply difference-into (first sets) (rest sets))))
+  (reduce (fn [acc s] (php/-> acc (difference s))) (union (first sets)) (rest sets)))
 
+(defn symmetricDifference
+  "Symmetric difference between multiple sets into a new one"
+  [& sets]
+  (reduce (fn [acc s] (php/-> acc (symmetricDifference s))) (union (first sets)) (rest sets)))
 
 # --------
 # For loop

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -6,6 +6,7 @@
   (:use Phel\Lang\IContactable)
   (:use Phel\Lang\PhelArray)
   (:use Phel\Lang\Table)
+  (:use Phel\Lang\Set)
   (:use Phel\Lang\Nil)
   (:use Phel\Lang\ICons)
   (:use Phel\Lang\ISlice)
@@ -184,6 +185,11 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`"
 # ------------------
 # Basic constructors
 # ------------------
+
+(defn set
+  "Creates a new Set. If no argument is provided, an empty Set is created."
+  [& xs]
+  (php/new Set xs))
 
 (defn keyword
   "Creates a new Keyword from a given string."
@@ -481,6 +487,7 @@ Calling the and function without arguments returns true."
   "Returns the type of `x`. Following types can be returned:
 
 * `:tuple`
+* `:set`
 * `:array`
 * `:struct`
 * `:table`
@@ -499,6 +506,7 @@ Calling the and function without arguments returns true."
   [x]
   (cond
     (php/instanceof x Tuple)      :tuple
+    (php/instanceof x Set)        :set
     (php/instanceof x PhelArray)  :array
     (php/instanceof x Struct)     :struct
     (php/instanceof x Table)      :table
@@ -614,6 +622,11 @@ Calling the and function without arguments returns true."
   (let [t (type x)]
     (or (= t :array) (= t :tuple) (= t :php/array))))
 
+(defn set?
+  "Returns true if `x` is a set, false otherwise."
+  [x]
+  (= (type x) :set))
+
 # ------------------
 # Sequence operation
 # ------------------
@@ -676,6 +689,32 @@ arrays. Use (php/aset ds key value)" )))
 arrays. Use (php/aunset ds key)" )))
     (php/aunset x key)
     x))
+
+(defn union
+  "Union multiple sets"
+  [& sets]
+  (apply concat sets))
+
+(defn intersection
+  "Intersect multiple sets into one"
+  [s & sets]
+  (do
+    (foreach [se sets]
+      (php/-> s (intersection se)))
+    s))
+
+(defn difference-into
+  "Difference between multiple sets into one"
+  [s & sets]
+  (do
+    (foreach [se sets]
+      (php/-> s (difference se)))
+    s))
+
+(defn difference
+  "Difference between multiple sets"
+  [& sets]
+  (apply difference-into (set) sets))
 
 
 # --------

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -691,25 +691,24 @@ arrays. Use (php/aunset ds key)" )))
     x))
 
 (defn union
-  "Union multiple sets"
+  "Union multiple sets into a new set"
   [& sets]
-  (apply concat sets))
+  (let (s (set))
+    (apply concat s sets)))
 
 (defn intersection
   "Intersect multiple sets into one"
   [s & sets]
-  (do
-    (foreach [se sets]
-      (php/-> s (intersection se)))
-    s))
+  (foreach [se sets]
+    (php/-> s (intersection se)))
+  s)
 
 (defn difference-into
   "Difference between multiple sets into one"
   [s & sets]
-  (do
-    (foreach [se sets]
-      (php/-> s (difference se)))
-    s))
+  (foreach [se sets]
+    (php/-> s (difference se)))
+  s)
 
 (defn difference
   "Difference between multiple sets"

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -713,7 +713,9 @@ arrays. Use (php/aunset ds key)" )))
 (defn difference
   "Difference between multiple sets"
   [& sets]
-  (apply difference-into (set) sets))
+  (if (= (count sets) 0)
+    (set)
+    (apply difference-into (first sets) (rest sets))))
 
 
 # --------

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -189,7 +189,7 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`"
 (defn set
   "Creates a new Set. If no argument is provided, an empty Set is created."
   [& xs]
-  (php/new Set xs))
+  (php/new Set (php/-> xs (toPhpArray))))
 
 (defn keyword
   "Creates a new Keyword from a given string."

--- a/src/php/Lang/Set.php
+++ b/src/php/Lang/Set.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Phel\Lang;
+
+use ArrayAccess;
+use Countable;
+use InvalidArgumentException;
+use Iterator;
+use Phel\Printer;
+
+class Set extends PhelArray implements ArrayAccess, Countable, Iterator, ICons, ISlice, ICdr, IRest, IPop, IRemove, IPush, IConcat {
+
+    /**
+     * @var mixed[]
+     */
+    protected $data = [];
+
+    /**
+     * Constructor
+     *
+     * @param mixed[] $data A list of all values
+     */
+    public function __construct(PhelArray $data)
+    {
+        parent::__construct([]);
+        $this->setData($data->toPhpArray());
+    }
+
+    /**
+     * Create a new array.
+     *
+     * @param mixed[] $values A list of all values
+     *
+     * @return Set
+     */
+    public static function create(...$values): Set
+    {
+        return new Set($values);
+    }
+
+    public function push($x): IPush {
+        if (!in_array($x, $this->data))
+            $this->data[] = $x;
+        return $this;
+    }
+
+    public function concat($xs): IConcat
+    {
+        foreach ($xs as $x) {
+            $this->push($x);
+        }
+        return $this;
+    }
+
+    public function union(Set $set): Set
+    {
+        return $this->concat($set->toPhpArray());
+    }
+
+    public function intersection(Set $set): Set
+    {
+        return $this->applySet($set, 'array_intersect');
+    }
+
+    public function difference(Set $set): Set
+    {
+        $rightDiff = new Set($set);
+        $rightDiff->applySet($this, 'array_diff');
+        $this->applySet($set, 'array_diff');
+        return $this->union($rightDiff);
+    }
+
+    public function equals($other): bool
+    {
+        return $this->toPhpArray() == $other->toPhpArray();
+    }
+
+    private function applySet(Set $set, callable $operation): Set
+    {
+        $this->setData($operation($this->data, $set->toPhpArray()));
+        return $this;
+    }
+
+    private function setData(array $data)
+    {
+        $this->data = array_values(array_unique($data));
+    }
+}

--- a/src/php/Lang/Set.php
+++ b/src/php/Lang/Set.php
@@ -98,16 +98,12 @@ class Set extends AbstractType implements Countable, Iterator, ICons, IPush, ICo
 
     public function intersection(Set $set): Set
     {
-        $this->data = array_intersect_key($this->data, $set->toPhpArray());
-        return $this;
+        return new Set(array_intersect_key($this->data, $set->toPhpArray()));
     }
 
     public function difference(Set $set): Set
     {
-        $difference = array_diff_key($this->data, $set->toPhpArray());
-        $this->data = [];
-        $this->concat($difference);
-        return $this;
+        return new Set(array_diff_key($this->data, $set->toPhpArray()));
     }
 
     public function equals($other): bool

--- a/src/php/Lang/Set.php
+++ b/src/php/Lang/Set.php
@@ -8,8 +8,13 @@ use InvalidArgumentException;
 use Iterator;
 use Phel\Printer;
 
-class Set extends PhelArray implements ArrayAccess, Countable, Iterator, ICons, ISlice, ICdr, IRest, IPop, IRemove, IPush, IConcat
+class Set extends Phel implements Countable, Iterator, ICons, IPush, IConcat
 {
+
+    /**
+     * @var mixed[]
+     */
+    protected $data = [];
 
     /**
      * Constructor
@@ -18,12 +23,11 @@ class Set extends PhelArray implements ArrayAccess, Countable, Iterator, ICons, 
      */
     public function __construct(array $data)
     {
-        parent::__construct([]);
         $this->setData($data);
     }
 
     /**
-     * Create a new array.
+     * Create a new set.
      *
      * @param mixed[] $values A list of all values
      *
@@ -34,11 +38,57 @@ class Set extends PhelArray implements ArrayAccess, Countable, Iterator, ICons, 
         return new Set($values);
     }
 
+    public function isTruthy(): bool
+    {
+        return true;
+    }
+
+    public function hash(): string
+    {
+        return spl_object_hash($this);
+    }
+
+    public function count(): int
+    {
+        return count($this->data);
+    }
+
+    public function current()
+    {
+        return current($this->data);
+    }
+
+    public function next()
+    {
+        next($this->data);
+    }
+
+    public function key()
+    {
+        return key($this->data);
+    }
+
+    public function valid()
+    {
+        return key($this->data) !== null;
+    }
+
+    public function rewind()
+    {
+        reset($this->data);
+    }
+
+    public function cons($x): ICons
+    {
+        array_unshift($this->data, $x);
+        return $this;
+    }
+
     public function push($x): IPush
     {
-        if (!in_array($x, $this->data)) {
-            $this->data[] = $x;
-        }
+        $hash = $this->offsetHash($x);
+        $this->data[$hash] = $x; // Don't need to check if $x is already there, just override.
+
         return $this;
     }
 
@@ -47,6 +97,7 @@ class Set extends PhelArray implements ArrayAccess, Countable, Iterator, ICons, 
         foreach ($xs as $x) {
             $this->push($x);
         }
+
         return $this;
     }
 
@@ -73,6 +124,11 @@ class Set extends PhelArray implements ArrayAccess, Countable, Iterator, ICons, 
         return $this->toPhpArray() == $other->toPhpArray();
     }
 
+    public function toPhpArray(): array
+    {
+        return $this->data;
+    }
+
     private function applySet(Set $set, callable $operation): Set
     {
         $this->setData($operation($this->data, $set->toPhpArray()));
@@ -81,6 +137,27 @@ class Set extends PhelArray implements ArrayAccess, Countable, Iterator, ICons, 
 
     private function setData(array $data)
     {
-        $this->data = array_values(array_unique($data));
+        $this->data = [];
+        $this->concat($data);
+    }
+
+    /**
+     * Creates a hash for the given key.
+     *
+     * @param mixed $offset The access key of the Set.
+     *
+     * @return string
+     */
+    private function offsetHash($offset): string
+    {
+        if ($offset instanceof Phel) {
+            return $offset->hash();
+        }
+
+        if (is_object($offset)) {
+            return spl_object_hash($offset);
+        }
+
+        return (string) $offset;
     }
 }

--- a/src/php/Lang/Set.php
+++ b/src/php/Lang/Set.php
@@ -8,22 +8,18 @@ use InvalidArgumentException;
 use Iterator;
 use Phel\Printer;
 
-class Set extends PhelArray implements ArrayAccess, Countable, Iterator, ICons, ISlice, ICdr, IRest, IPop, IRemove, IPush, IConcat {
-
-    /**
-     * @var mixed[]
-     */
-    protected $data = [];
+class Set extends PhelArray implements ArrayAccess, Countable, Iterator, ICons, ISlice, ICdr, IRest, IPop, IRemove, IPush, IConcat
+{
 
     /**
      * Constructor
      *
      * @param mixed[] $data A list of all values
      */
-    public function __construct(PhelArray $data)
+    public function __construct(array $data)
     {
         parent::__construct([]);
-        $this->setData($data->toPhpArray());
+        $this->setData($data);
     }
 
     /**
@@ -38,9 +34,11 @@ class Set extends PhelArray implements ArrayAccess, Countable, Iterator, ICons, 
         return new Set($values);
     }
 
-    public function push($x): IPush {
-        if (!in_array($x, $this->data))
+    public function push($x): IPush
+    {
+        if (!in_array($x, $this->data)) {
             $this->data[] = $x;
+        }
         return $this;
     }
 
@@ -52,19 +50,19 @@ class Set extends PhelArray implements ArrayAccess, Countable, Iterator, ICons, 
         return $this;
     }
 
-    public function union(Set $set): Set
+    public function union(Set $set): IConcat
     {
         return $this->concat($set->toPhpArray());
     }
 
-    public function intersection(Set $set): Set
+    public function intersection(Set $set): IConcat
     {
         return $this->applySet($set, 'array_intersect');
     }
 
-    public function difference(Set $set): Set
+    public function difference(Set $set): IConcat
     {
-        $rightDiff = new Set($set);
+        $rightDiff = new Set($set->toPhpArray());
         $rightDiff->applySet($this, 'array_diff');
         $this->applySet($set, 'array_diff');
         return $this->union($rightDiff);

--- a/src/php/Lang/Set.php
+++ b/src/php/Lang/Set.php
@@ -90,12 +90,6 @@ class Set extends AbstractType implements Countable, Iterator, ICons, IPush, ICo
         return $this;
     }
 
-    public function union(Set $set): Set
-    {
-        $this->concat($set->toPhpArray());
-        return $this;
-    }
-
     public function intersection(Set $set): Set
     {
         return new Set(array_intersect_key($this->data, $set->toPhpArray()));

--- a/src/php/Lang/Set.php
+++ b/src/php/Lang/Set.php
@@ -110,16 +110,6 @@ class Set extends AbstractType implements Countable, Iterator, ICons, IPush, ICo
         return $this;
     }
 
-    public function symmetricDifference(Set $set): Set
-    {
-        $ldiff = array_diff_key($this->data, $set->toPhpArray());
-        $rdiff = array_diff_key($set->toPhpArray(), $this->data);
-        $this->data = [];
-        $this->concat($ldiff);
-        $this->concat($rdiff);
-        return $this;
-    }
-
     public function equals($other): bool
     {
         return $this->toPhpArray() == $other->toPhpArray();

--- a/src/php/Lang/Set.php
+++ b/src/php/Lang/Set.php
@@ -23,19 +23,8 @@ class Set extends AbstractType implements Countable, Iterator, ICons, IPush, ICo
      */
     public function __construct(array $data)
     {
-        $this->setData($data);
-    }
-
-    /**
-     * Create a new set.
-     *
-     * @param mixed[] $values A list of all values
-     *
-     * @return Set
-     */
-    public static function create(...$values): Set
-    {
-        return new Set($values);
+        $this->data = [];
+        $this->concat($data);
     }
 
     public function isTruthy(): bool
@@ -115,6 +104,14 @@ class Set extends AbstractType implements Countable, Iterator, ICons, IPush, ICo
 
     public function difference(Set $set): Set
     {
+        $difference = array_diff_key($this->data, $set->toPhpArray());
+        $this->data = [];
+        $this->concat($difference);
+        return $this;
+    }
+
+    public function symmetricDifference(Set $set): Set
+    {
         $ldiff = array_diff_key($this->data, $set->toPhpArray());
         $rdiff = array_diff_key($set->toPhpArray(), $this->data);
         $this->data = [];
@@ -131,12 +128,6 @@ class Set extends AbstractType implements Countable, Iterator, ICons, IPush, ICo
     public function toPhpArray(): array
     {
         return $this->data;
-    }
-
-    private function setData(array $data)
-    {
-        $this->data = [];
-        $this->concat($data);
     }
 
     /**
@@ -157,5 +148,10 @@ class Set extends AbstractType implements Countable, Iterator, ICons, IPush, ICo
         }
 
         return (string) $offset;
+    }
+
+    public function __toString(): string
+    {
+        return Printer::readable()->print($this);
     }
 }

--- a/src/php/Printer.php
+++ b/src/php/Printer.php
@@ -218,6 +218,6 @@ final class Printer
             $args[] = $this->print($elem);
         }
 
-        return $prefix . implode(" ", $args) . $suffix;
+        return $prefix . implode(' ', $args) . $suffix;
     }
 }

--- a/src/php/Printer.php
+++ b/src/php/Printer.php
@@ -210,7 +210,7 @@ final class Printer
 
     private function printSet(Set $form): string
     {
-        $prefix = '@(';
+        $prefix = '(set ';
         $suffix = ')';
 
         $args = [];

--- a/src/php/Printer.php
+++ b/src/php/Printer.php
@@ -12,6 +12,7 @@ use Phel\Lang\Struct;
 use Phel\Lang\Symbol;
 use Phel\Lang\Table;
 use Phel\Lang\Tuple;
+use Phel\Lang\Set;
 
 final class Printer
 {
@@ -47,6 +48,9 @@ final class Printer
         }
         if ($form instanceof Symbol) {
             return $form->getName();
+        }
+        if ($form instanceof Set) {
+            return $this->printSet($form);
         }
         if ($form instanceof PhelArray) {
             return $this->printArray($form);
@@ -202,5 +206,18 @@ final class Printer
         }
 
         return $prefix . implode(' ', $args) . $suffix;
+    }
+
+    private function printSet(Set $form): string
+    {
+        $prefix = '@(';
+        $suffix = ')';
+
+        $args = [];
+        foreach ($form as $elem) {
+            $args[] = $this->print($elem);
+        }
+
+        return $prefix . implode(" ", $args) . $suffix;
     }
 }

--- a/src/php/Printer.php
+++ b/src/php/Printer.php
@@ -210,7 +210,7 @@ final class Printer
 
     private function printSet(Set $form): string
     {
-        $prefix = '(set ';
+        $prefix = '(set';
         $suffix = ')';
 
         $args = [];
@@ -218,6 +218,6 @@ final class Printer
             $args[] = $this->print($elem);
         }
 
-        return $prefix . implode(' ', $args) . $suffix;
+        return $prefix . (count($args) > 0 ? ' ' : '') . implode(' ', $args) . $suffix;
     }
 }

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -61,6 +61,7 @@
 (assert (= @[1 2 3] (array 1 2 3)) "construct array")
 (assert (= :a (keyword "a")) "construct keyword")
 (assert (= @{:a 1 :b 2} (table :a 1 :b 2)) "construct table")
+(assert (= (set 1 2 3 :a :b :c) (set 1 2 3 :a :b :c :c 1 2 3)) "construct set")
 
 (let [arr (php-indexed-array "a" "b")]
   (assert (= "a" (php/aget arr 0)) "php-associative-array: first key")
@@ -281,6 +282,7 @@
 (assert (= :tuple (type [])) "type of bracket tuple")
 (assert (= :tuple (type '())) "type of tuple")
 (assert (= :table (type @{})) "type of table")
+(assert (= :set (type (set))) "type of set")
 (assert (= :keyword (type :test)) "type of keyword")
 (assert (= :symbol (type 'x)) "type of symbol")
 (assert (= :int (type 10)) "type of int")
@@ -593,6 +595,18 @@
 
 (assert (= @[1 2 3 4 5 6 7] (flatten [1 [2 [3 4 [5]] 6 [7]]])) "flatten")
 (assert (= @[] (flatten nil)) "flatten nil")
+
+(assert (= (set 1 2 3) (push (set 1 2) 3)) "set push")
+(assert (= (set 1 2) (push (set 1 2) 2)) "set push existing value")
+(assert (= (set 1 2 0 3) (concat (set 1 2) @[0 3])) "set concat array")
+(assert (= (set 1 2 0 3) (concat (set 1 2) @[0 1 2 3])) "set concat array with common values")
+(assert (= (set 1 2 0) (concat (set 1 2) (set 0 1))) "set concat")
+(assert (= (set 1 2 0 3) (union (set 1 2) (set 0 3))) "set union")
+(assert (= (set 1 2 0 3) (union (set 1 2) (set 0 1 2 3))) "set union with common values")
+(assert (= (set) (intersection (set 1 2) (set 0 3))) "set intersection")
+(assert (= (set 1 2) (intersection (set 1 2) (set 0 1 2 3))) "set intersection with common values")
+(assert (= (set 1 2 0 3) (difference (set 1 2) (set 0 3))) "set difference")
+(assert (= (set 0 3) (difference (set 1 2) (set 0 1 2 3))) "set difference with common values")
 
 # ------------------
 # Function operation

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -601,6 +601,7 @@
 (assert (= (set 1 2 0 3) (concat (set 1 2) @[0 3])) "set concat array")
 (assert (= (set 1 2 0 3) (concat (set 1 2) @[0 1 2 3])) "set concat array with common values")
 (assert (= (set 1 2 0) (concat (set 1 2) (set 0 1))) "set concat")
+(assert (= (set) (union)) "set 0-ary union")
 (assert (= (set 1 2 0 3) (union (set 1 2) (set 0 3))) "set union")
 (assert (= (set 1 2 0 3) (union (set 1 2) (set 0 1 2 3))) "set union with common values")
 (assert (= (set) (intersection (set 1 2) (set 0 3))) "set intersection")

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -607,18 +607,15 @@
 (assert (= (set 1 2 0 3) (union (set 1 2) (set 0 3))) "set union")
 (assert (= (set 1 2 0 3) (union (set 1 2) (set 0 1 2 3))) "set union with common values")
 
-(assert (= (set) (intersection)) "set 0-ary intersection")
 (assert (= (set) (intersection (set 1 2) (set 0 3))) "set intersection")
 (assert (= (set 1 2) (intersection (set 1 2) (set 0 1 2 3))) "set intersection with common values")
 
-(assert (= (set) (difference)) "set 0-ary difference")
 (assert (= (set 1 2) (difference (set 1 2) (set 0 3))) "set difference")
 (assert (= (set) (difference (set 1 2) (set 0 1 2 3))) "set difference")
 (assert (= (set 0 3) (difference (set 0 1 2 3) (set 1 2 ))) "set difference with common values")
 
-(assert (= (set) (symmetricDifference)) "set 0-ary symmetricDifference")
-(assert (= (set 1 2 0 3) (symmetricDifference (set 1 2) (set 0 3))) "set symmetricDifference")
-(assert (= (set 0 3) (symmetricDifference (set 1 2) (set 0 1 2 3))) "set symmetricDifference with common values")
+(assert (= (set 1 2 0 3) (symmetric-difference (set 1 2) (set 0 3))) "set symmetric-difference")
+(assert (= (set 0 3) (symmetric-difference (set 1 2) (set 0 1 2 3))) "set symmetric-difference with common values")
 
 # ------------------
 # Function operation

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -598,16 +598,21 @@
 
 (assert (= (set 1 2 3) (push (set 1 2) 3)) "set push")
 (assert (= (set 1 2) (push (set 1 2) 2)) "set push existing value")
+
 (assert (= (set 1 2 0 3) (concat (set 1 2) @[0 3])) "set concat array")
 (assert (= (set 1 2 0 3) (concat (set 1 2) @[0 1 2 3])) "set concat array with common values")
 (assert (= (set 1 2 0) (concat (set 1 2) (set 0 1))) "set concat")
+
 (assert (= (set) (union)) "set 0-ary union")
 (assert (= (set 1 2 0 3) (union (set 1 2) (set 0 3))) "set union")
 (assert (= (set 1 2 0 3) (union (set 1 2) (set 0 1 2 3))) "set union with common values")
+
 (assert (= (set) (intersection (set 1 2) (set 0 3))) "set intersection")
 (assert (= (set 1 2) (intersection (set 1 2) (set 0 1 2 3))) "set intersection with common values")
-(assert (= (set 1 2 0 3) (difference (set 1 2) (set 0 3))) "set difference")
-(assert (= (set 0 3) (difference (set 1 2) (set 0 1 2 3))) "set difference with common values")
+
+(assert (= (set 1 2) (difference (set 1 2) (set 0 3))) "set difference")
+(assert (= (set) (difference (set 1 2) (set 0 1 2 3))) "set difference")
+(assert (= (set 0 3) (difference (set 0 1 2 3) (set 1 2 ))) "set difference with common values")
 
 # ------------------
 # Function operation
@@ -752,6 +757,7 @@
 (assert (= "[\"a\" \"b\"]" (str ["a" "b"])) "str with tuple of strings")
 (assert (= "@[\"a\" \"b\"]" (str @["a" "b"])) "str with array of strings")
 (assert (= "@{\"a\" \"b\"}" (str @{"a" "b"})) "str on table")
+(assert (= "(set \"a\" \"b\")" (str (set "a" "b"))) "str on set")
 (assert (= "x" (str 'x)) "str on symbol")
 (assert (= ":test" (str :test)) "str on keyword")
 (assert (= "1" (str 1)) "str on number")
@@ -766,6 +772,7 @@
 (assert (= "[a b]" (print-str ["a" "b"])) "print-str with tuple of strings")
 (assert (= "@[a b]" (print-str @["a" "b"])) "print-str with array of strings")
 (assert (= "@{a b}" (print-str @{"a" "b"})) "print-str on table")
+(assert (= "(set a b)" (print-str (set "a" "b"))) "print-str on set")
 (assert (= "x" (print-str 'x)) "print-str on symbol")
 (assert (= ":test" (print-str :test)) "print-str on keyword")
 (assert (= "1" (print-str 1)) "print-str on number")

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -607,12 +607,18 @@
 (assert (= (set 1 2 0 3) (union (set 1 2) (set 0 3))) "set union")
 (assert (= (set 1 2 0 3) (union (set 1 2) (set 0 1 2 3))) "set union with common values")
 
+(assert (= (set) (intersection)) "set 0-ary intersection")
 (assert (= (set) (intersection (set 1 2) (set 0 3))) "set intersection")
 (assert (= (set 1 2) (intersection (set 1 2) (set 0 1 2 3))) "set intersection with common values")
 
+(assert (= (set) (difference)) "set 0-ary difference")
 (assert (= (set 1 2) (difference (set 1 2) (set 0 3))) "set difference")
 (assert (= (set) (difference (set 1 2) (set 0 1 2 3))) "set difference")
 (assert (= (set 0 3) (difference (set 0 1 2 3) (set 1 2 ))) "set difference with common values")
+
+(assert (= (set) (symmetricDifference)) "set 0-ary symmetricDifference")
+(assert (= (set 1 2 0 3) (symmetricDifference (set 1 2) (set 0 3))) "set symmetricDifference")
+(assert (= (set 0 3) (symmetricDifference (set 1 2) (set 0 1 2 3))) "set symmetricDifference with common values")
 
 # ------------------
 # Function operation


### PR DESCRIPTION
# Description

This implements the set data structure described by #5. However I didn't implement the `join` function as it seems to be a duplicate of `union`.

However, I didn't update the documentation yet, I would like to get an approbation about this update first.

I tried to figure out how to parse a set with a custom notation (I was thinking about `@(1 2 3)` since this notation is not used yet and is close to another notation used in the language), but I couldn't understand what I should do exactly to get this result.

# Changes

- Added tests on Sets
- Added a Set php class derived from PhelArray
- Added Set phel constructor and functions
  - `(set 1 2 3 1 2 3)` create a set containing the values 1, 2 and 3 (only once since it's a set)
  - `union (set 1) (set 2) (set 3)` update the values of the first set to the given sets unions
  - `intersection (set 1) (set 2) (set 3)` update the values of the first set to the given sets intersections
  - `difference (set 1) (set 2) (set 3)` update the values of the first set to the given sets differences