### PR TITLE
Refactor TupleSymbols

### DIFF
--- a/src/php/Analyzer/TupleSymbol/ApplySymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ApplySymbol.php
@@ -6,6 +6,7 @@ namespace Phel\Analyzer\TupleSymbol;
 
 use Phel\Analyzer\WithAnalyzer;
 use Phel\Ast\ApplyNode;
+use Phel\Ast\Node;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
@@ -14,32 +15,35 @@ final class ApplySymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $x, NodeEnvironment $env): ApplyNode
+    public function __invoke(Tuple $tuple, NodeEnvironment $env): ApplyNode
     {
-        $tupleCount = count($x);
-        if ($tupleCount < 3) {
-            throw new AnalyzerException(
-                "At least three arguments are required for 'apply",
-                $x->getStartLocation(),
-                $x->getEndLocation()
-            );
-        }
-
-        $fn = $this->analyzer->analyze($x[1], $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame());
-
-        $args = [];
-        for ($i = 2; $i < $tupleCount; $i++) {
-            $args[] = $this->analyzer->analyze(
-                $x[$i],
-                $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()
-            );
+        if (count($tuple) < 3) {
+            throw AnalyzerException::withLocation("At least three arguments are required for 'apply", $tuple);
         }
 
         return new ApplyNode(
             $env,
-            $fn,
-            $args,
-            $x->getStartLocation()
+            $this->analyze($tuple[1], $env),
+            $this->arguments($tuple, $env),
+            $tuple->getStartLocation()
         );
+    }
+
+    private function analyze($x, NodeEnvironment $env): Node
+    {
+        return $this->analyzer->analyze(
+            $x,
+            $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()
+        );
+    }
+
+    private function arguments(Tuple $x, NodeEnvironment $env): array
+    {
+        $args = [];
+        for ($i = 2, $iMax = count($x); $i < $iMax; $i++) {
+            $args[] = $this->analyze($x[$i], $env);
+        }
+
+        return $args;
     }
 }

--- a/src/php/Analyzer/TupleSymbol/ApplySymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ApplySymbol.php
@@ -23,13 +23,13 @@ final class ApplySymbol
 
         return new ApplyNode(
             $env,
-            $this->analyze($tuple[1], $env),
+            $this->fnExpr($tuple[1], $env),
             $this->arguments($tuple, $env),
             $tuple->getStartLocation()
         );
     }
 
-    private function analyze($x, NodeEnvironment $env): Node
+    private function fnExpr($x, NodeEnvironment $env): Node
     {
         return $this->analyzer->analyze(
             $x,
@@ -41,7 +41,7 @@ final class ApplySymbol
     {
         $args = [];
         for ($i = 2, $iMax = count($x); $i < $iMax; $i++) {
-            $args[] = $this->analyze($x[$i], $env);
+            $args[] = $this->fnExpr($x[$i], $env);
         }
 
         return $args;

--- a/src/php/Analyzer/TupleSymbol/DefStructSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DefStructSymbol.php
@@ -15,53 +15,42 @@ final class DefStructSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $x, NodeEnvironment $env): DefStructNode
+    public function __invoke(Tuple $tuple, NodeEnvironment $env): DefStructNode
     {
-        if (count($x) !== 3) {
-            throw new AnalyzerException(
-                "Exactly two arguments are required for 'defstruct. Got " . count($x),
-                $x->getStartLocation(),
-                $x->getEndLocation()
+        if (count($tuple) !== 3) {
+            throw AnalyzerException::withLocation(
+                "Exactly two arguments are required for 'defstruct. Got " . count($tuple),
+                $tuple
             );
         }
 
-        if (!($x[1] instanceof Symbol)) {
-            throw new AnalyzerException(
-                "First arugment of 'defstruct must be a Symbol.",
-                $x->getStartLocation(),
-                $x->getEndLocation()
-            );
+        if (!($tuple[1] instanceof Symbol)) {
+            throw AnalyzerException::withLocation("First argument of 'defstruct must be a Symbol.", $tuple);
         }
 
-        if (!($x[2] instanceof Tuple)) {
-            throw new AnalyzerException(
-                "Second arugment of 'defstruct must be a Tuple.",
-                $x->getStartLocation(),
-                $x->getEndLocation()
-            );
+        if (!($tuple[2] instanceof Tuple)) {
+            throw AnalyzerException::withLocation("Second argument of 'defstruct must be a Tuple.", $tuple);
         }
-
-        $params = [];
-        foreach ($x[2] as $element) {
-            if (!($element instanceof Symbol)) {
-                throw new AnalyzerException(
-                    'Defstruct field elements must by Symbols.',
-                    $element->getStartLocation(),
-                    $element->getEndLocation()
-                );
-            }
-
-            $params[] = $element;
-        }
-
-        $namespace = $this->analyzer->getGlobalEnvironment()->getNs();
 
         return new DefStructNode(
             $env,
-            $namespace,
-            $x[1],
-            $params,
-            $x->getStartLocation()
+            $this->analyzer->getGlobalEnvironment()->getNs(),
+            $tuple[1],
+            $this->params($tuple[2]),
+            $tuple->getStartLocation()
         );
+    }
+
+    private function params(Tuple $tuple): array
+    {
+        $params = [];
+        foreach ($tuple as $element) {
+            if (!($element instanceof Symbol)) {
+                throw AnalyzerException::withLocation('Defstruct field elements must be Symbols.', $tuple);
+            }
+            $params[] = $element;
+        }
+
+        return $params;
     }
 }

--- a/src/php/Analyzer/TupleSymbol/DoSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DoSymbol.php
@@ -24,22 +24,30 @@ final class DoSymbol
             );
         }
 
+        return new DoNode(
+            $env,
+            $stmts,
+            $this->ret($tuple, $env),
+            $tuple->getStartLocation()
+        );
+    }
+
+    private function ret($tuple, $env)
+    {
+        $tupleCount = count($tuple);
+
         if ($tupleCount > 2) {
             $retEnv = $env->getContext() === NodeEnvironment::CTX_STMT
                 ? $env->withContext(NodeEnvironment::CTX_STMT)
                 : $env->withContext(NodeEnvironment::CTX_RET);
-            $ret = $this->analyzer->analyze($tuple[$tupleCount - 1], $retEnv);
-        } elseif ($tupleCount === 2) {
-            $ret = $this->analyzer->analyze($tuple[$tupleCount - 1], $env);
-        } else {
-            $ret = $this->analyzer->analyze(null, $env);
+
+            return $this->analyzer->analyze($tuple[$tupleCount - 1], $retEnv);
         }
 
-        return new DoNode(
-            $env,
-            $stmts,
-            $ret,
-            $tuple->getStartLocation()
-        );
+        if ($tupleCount === 2) {
+            return $this->analyzer->analyze($tuple[$tupleCount - 1], $env);
+        }
+
+        return $this->analyzer->analyze(null, $env);
     }
 }

--- a/src/php/Analyzer/TupleSymbol/DoSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DoSymbol.php
@@ -13,21 +13,24 @@ final class DoSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $x, NodeEnvironment $env): DoNode
+    public function __invoke(Tuple $tuple, NodeEnvironment $env): DoNode
     {
-        $tupleCount = count($x);
+        $tupleCount = count($tuple);
         $stmts = [];
         for ($i = 1; $i < $tupleCount - 1; $i++) {
-            $stmts[] = $this->analyzer->analyze($x[$i], $env->withContext(NodeEnvironment::CTX_STMT)->withDisallowRecurFrame());
+            $stmts[] = $this->analyzer->analyze(
+                $tuple[$i],
+                $env->withContext(NodeEnvironment::CTX_STMT)->withDisallowRecurFrame()
+            );
         }
 
         if ($tupleCount > 2) {
             $retEnv = $env->getContext() === NodeEnvironment::CTX_STMT
                 ? $env->withContext(NodeEnvironment::CTX_STMT)
                 : $env->withContext(NodeEnvironment::CTX_RET);
-            $ret = $this->analyzer->analyze($x[$tupleCount - 1], $retEnv);
+            $ret = $this->analyzer->analyze($tuple[$tupleCount - 1], $retEnv);
         } elseif ($tupleCount === 2) {
-            $ret = $this->analyzer->analyze($x[$tupleCount - 1], $env);
+            $ret = $this->analyzer->analyze($tuple[$tupleCount - 1], $env);
         } else {
             $ret = $this->analyzer->analyze(null, $env);
         }
@@ -36,7 +39,7 @@ final class DoSymbol
             $env,
             $stmts,
             $ret,
-            $x->getStartLocation()
+            $tuple->getStartLocation()
         );
     }
 }

--- a/src/php/Analyzer/TupleSymbol/FnSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/FnSymbol.php
@@ -16,23 +16,15 @@ final class FnSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $x, NodeEnvironment $env): FnNode
+    public function __invoke(Tuple $tuple, NodeEnvironment $env): FnNode
     {
-        $tupleCount = count($x);
+        $tupleCount = count($tuple);
         if ($tupleCount < 2) {
-            throw new AnalyzerException(
-                "'fn requires at least one argument",
-                $x->getStartLocation(),
-                $x->getEndLocation()
-            );
+            throw AnalyzerException::withLocation("'fn requires at least one argument", $tuple);
         }
 
-        if (!($x[1] instanceof Tuple)) {
-            throw new AnalyzerException(
-                "Second argument of 'fn must be a Tuple",
-                $x->getStartLocation(),
-                $x->getEndLocation()
-            );
+        if (!($tuple[1] instanceof Tuple)) {
+            throw AnalyzerException::withLocation("Second argument of 'fn must be a Tuple", $tuple);
         }
 
         $params = [];
@@ -40,7 +32,7 @@ final class FnSymbol
         $isVariadic = false;
         $hasVariadicForm = false;
         $state = 'start';
-        $xs = $x[1];
+        $xs = $tuple[1];
         foreach ($xs as $param) {
             switch ($state) {
                 case 'start':
@@ -68,17 +60,16 @@ final class FnSymbol
                     } elseif ($param instanceof Symbol) {
                         $params[] = $param;
                     } else {
-                        $tempSym = Symbol::gen()->copyLocationFrom($x);
+                        $tempSym = Symbol::gen()->copyLocationFrom($tuple);
                         $params[] = $tempSym;
                         $lets[] = $param;
                         $lets[] = $tempSym;
                     }
                     break;
                 case 'done':
-                    throw new AnalyzerException(
+                    throw AnalyzerException::withLocation(
                         'Unsupported parameter form, only one symbol can follow the & parameter',
-                        $x->getStartLocation(),
-                        $x->getEndLocation()
+                        $tuple
                     );
             }
         }
@@ -90,17 +81,16 @@ final class FnSymbol
 
         foreach ($params as $param) {
             if (!(preg_match("/^[a-zA-Z_\x80-\xff].*$/", $param->getName()))) {
-                throw new AnalyzerException(
+                throw AnalyzerException::withLocation(
                     "Variable names must start with a letter or underscore: {$param->getName()}",
-                    $x->getStartLocation(),
-                    $x->getEndLocation()
+                    $tuple
                 );
             }
         }
 
         $recurFrame = new RecurFrame($params);
+        $body = array_slice($tuple->toArray(), 2);
 
-        $body = array_slice($x->toArray(), 2);
         if (count($lets) > 0) {
             $body = Tuple::create(
                 (new Symbol('let'))->copyLocationFrom($body),
@@ -120,7 +110,6 @@ final class FnSymbol
             ->withAddedRecurFrame($recurFrame);
 
         $body = $this->analyzer->analyze($body, $bodyEnv);
-
         $uses = array_diff($env->getLocals(), $params);
 
         return new FnNode(
@@ -130,7 +119,7 @@ final class FnSymbol
             $uses,
             $isVariadic,
             $recurFrame->isActive(),
-            $x->getStartLocation()
+            $tuple->getStartLocation()
         );
     }
 

--- a/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
@@ -15,38 +15,35 @@ final class ForeachSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $x, NodeEnvironment $env): ForeachNode
+    public function __invoke(Tuple $tuple, NodeEnvironment $env): ForeachNode
     {
-        $tupleCount = count($x);
+        $tupleCount = count($tuple);
         if ($tupleCount < 2) {
-            throw new AnalyzerException(
+            throw AnalyzerException::withLocation(
                 "At least two arguments are required for 'foreach",
-                $x->getStartLocation(),
-                $x->getEndLocation()
+                $tuple
             );
         }
 
-        if (!($x[1] instanceof Tuple)) {
-            throw new AnalyzerException(
+        if (!($tuple[1] instanceof Tuple)) {
+            throw AnalyzerException::withLocation(
                 "First argument of 'foreach must be a tuple.",
-                $x->getStartLocation(),
-                $x->getEndLocation()
+                $tuple
             );
         }
 
-        if (count($x[1]) !== 2 && count($x[1]) !== 3) {
-            throw new AnalyzerException(
+        if (count($tuple[1]) !== 2 && count($tuple[1]) !== 3) {
+            throw AnalyzerException::withLocation(
                 "Tuple of 'foreach must have exactly two or three elements.",
-                $x->getStartLocation(),
-                $x->getEndLocation()
+                $tuple
             );
         }
 
         $lets = [];
-        if (count($x[1]) === 2) {
+        if (count($tuple[1]) === 2) {
             $keySymbol = null;
 
-            $valueSymbol = $x[1][0];
+            $valueSymbol = $tuple[1][0];
             if (!($valueSymbol instanceof Symbol)) {
                 $tmpSym = Symbol::gen();
                 $lets[] = $valueSymbol;
@@ -54,9 +51,12 @@ final class ForeachSymbol
                 $valueSymbol = $tmpSym;
             }
             $bodyEnv = $env->withMergedLocals([$valueSymbol]);
-            $listExpr = $this->analyzer->analyze($x[1][1], $env->withContext(NodeEnvironment::CTX_EXPR));
+            $listExpr = $this->analyzer->analyze(
+                $tuple[1][1],
+                $env->withContext(NodeEnvironment::CTX_EXPR)
+            );
         } else {
-            $keySymbol = $x[1][0];
+            $keySymbol = $tuple[1][0];
             if (!($keySymbol instanceof Symbol)) {
                 $tmpSym = Symbol::gen();
                 $lets[] = $keySymbol;
@@ -64,7 +64,7 @@ final class ForeachSymbol
                 $keySymbol = $tmpSym;
             }
 
-            $valueSymbol = $x[1][1];
+            $valueSymbol = $tuple[1][1];
             if (!($valueSymbol instanceof Symbol)) {
                 $tmpSym = Symbol::gen();
                 $lets[] = $valueSymbol;
@@ -73,12 +73,15 @@ final class ForeachSymbol
             }
 
             $bodyEnv = $env->withMergedLocals([$valueSymbol, $keySymbol]);
-            $listExpr = $this->analyzer->analyze($x[1][2], $env->withContext(NodeEnvironment::CTX_EXPR));
+            $listExpr = $this->analyzer->analyze(
+                $tuple[1][2],
+                $env->withContext(NodeEnvironment::CTX_EXPR)
+            );
         }
 
         $bodys = [];
         for ($i = 2; $i < $tupleCount; $i++) {
-            $bodys[] = $x[$i];
+            $bodys[] = $tuple[$i];
         }
 
         if (count($lets)) {
@@ -87,7 +90,10 @@ final class ForeachSymbol
             $body = Tuple::create(new Symbol('do'), ...$bodys);
         }
 
-        $bodyExpr = $this->analyzer->analyze($body, $bodyEnv->withContext(NodeEnvironment::CTX_STMT));
+        $bodyExpr = $this->analyzer->analyze(
+            $body,
+            $bodyEnv->withContext(NodeEnvironment::CTX_STMT)
+        );
 
         return new ForeachNode(
             $env,
@@ -95,7 +101,7 @@ final class ForeachSymbol
             $listExpr,
             $valueSymbol,
             $keySymbol,
-            $x->getStartLocation()
+            $tuple->getStartLocation()
         );
     }
 }

--- a/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
@@ -19,24 +19,15 @@ final class ForeachSymbol
     {
         $tupleCount = count($tuple);
         if ($tupleCount < 2) {
-            throw AnalyzerException::withLocation(
-                "At least two arguments are required for 'foreach",
-                $tuple
-            );
+            throw AnalyzerException::withLocation("At least two arguments are required for 'foreach", $tuple);
         }
 
         if (!($tuple[1] instanceof Tuple)) {
-            throw AnalyzerException::withLocation(
-                "First argument of 'foreach must be a tuple.",
-                $tuple
-            );
+            throw AnalyzerException::withLocation("First argument of 'foreach must be a tuple.", $tuple);
         }
 
         if (count($tuple[1]) !== 2 && count($tuple[1]) !== 3) {
-            throw AnalyzerException::withLocation(
-                "Tuple of 'foreach must have exactly two or three elements.",
-                $tuple
-            );
+            throw AnalyzerException::withLocation("Tuple of 'foreach must have exactly two or three elements.", $tuple);
         }
 
         $lets = [];

--- a/src/php/Analyzer/TupleSymbol/InvokeSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/InvokeSymbol.php
@@ -82,7 +82,7 @@ final class InvokeSymbol
         throw AnalyzerException::withLocation('This is not macro expandable: ' . get_class($node), $tuple);
     }
 
-    /** @param Tuple|AbstractType $x */
+    /** @param AbstractType|scalar|null $x */
     private function enrichLocation($x, AbstractType $parent): void
     {
         if ($x instanceof Tuple) {
@@ -106,6 +106,7 @@ final class InvokeSymbol
         if (!$type->getStartLocation()) {
             $type->setStartLocation($parent->getStartLocation());
         }
+
         if (!$type->getEndLocation()) {
             $type->setEndLocation($parent->getEndLocation());
         }

--- a/src/php/Analyzer/TupleSymbol/PhpAGetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAGetSymbol.php
@@ -13,13 +13,13 @@ final class PhpAGetSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $x, NodeEnvironment $env): PhpArrayGetNode
+    public function __invoke(Tuple $tuple, NodeEnvironment $env): PhpArrayGetNode
     {
         return new PhpArrayGetNode(
             $env,
-            $this->analyzer->analyze($x[1], $env->withContext(NodeEnvironment::CTX_EXPR)),
-            $this->analyzer->analyze($x[2], $env->withContext(NodeEnvironment::CTX_EXPR)),
-            $x->getStartLocation()
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CTX_EXPR)),
+            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CTX_EXPR)),
+            $tuple->getStartLocation()
         );
     }
 }

--- a/src/php/Analyzer/TupleSymbol/PhpAPushSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAPushSymbol.php
@@ -13,13 +13,13 @@ final class PhpAPushSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $x, NodeEnvironment $env): PhpArrayPushNode
+    public function __invoke(Tuple $tuple, NodeEnvironment $env): PhpArrayPushNode
     {
         return new PhpArrayPushNode(
             $env,
-            $this->analyzer->analyze($x[1], $env->withContext(NodeEnvironment::CTX_EXPR)),
-            $this->analyzer->analyze($x[2], $env->withContext(NodeEnvironment::CTX_EXPR)),
-            $x->getStartLocation()
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CTX_EXPR)),
+            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CTX_EXPR)),
+            $tuple->getStartLocation()
         );
     }
 }

--- a/src/php/Analyzer/TupleSymbol/PhpASetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpASetSymbol.php
@@ -13,14 +13,14 @@ final class PhpASetSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $x, NodeEnvironment $env): PhpArraySetNode
+    public function __invoke(Tuple $tuple, NodeEnvironment $env): PhpArraySetNode
     {
         return new PhpArraySetNode(
             $env,
-            $this->analyzer->analyze($x[1], $env->withContext(NodeEnvironment::CTX_EXPR)),
-            $this->analyzer->analyze($x[2], $env->withContext(NodeEnvironment::CTX_EXPR)),
-            $this->analyzer->analyze($x[3], $env->withContext(NodeEnvironment::CTX_EXPR)),
-            $x->getStartLocation()
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CTX_EXPR)),
+            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CTX_EXPR)),
+            $this->analyzer->analyze($tuple[3], $env->withContext(NodeEnvironment::CTX_EXPR)),
+            $tuple->getStartLocation()
         );
     }
 }

--- a/src/php/Analyzer/TupleSymbol/PhpAUnsetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAUnsetSymbol.php
@@ -14,21 +14,17 @@ final class PhpAUnsetSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $x, NodeEnvironment $env): PhpArrayUnsetNode
+    public function __invoke(Tuple $tuple, NodeEnvironment $env): PhpArrayUnsetNode
     {
         if ($env->getContext() !== NodeEnvironment::CTX_STMT) {
-            throw new AnalyzerException(
-                "'php/unset can only be called as Statement and not as Expression",
-                $x->getStartLocation(),
-                $x->getEndLocation()
-            );
+            throw AnalyzerException::withLocation("'php/unset can only be called as Statement and not as Expression", $tuple);
         }
 
         return new PhpArrayUnsetNode(
             $env,
-            $this->analyzer->analyze($x[1], $env->withContext(NodeEnvironment::CTX_EXPR)),
-            $this->analyzer->analyze($x[2], $env->withContext(NodeEnvironment::CTX_EXPR)),
-            $x->getStartLocation()
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CTX_EXPR)),
+            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CTX_EXPR)),
+            $tuple->getStartLocation()
         );
     }
 }

--- a/src/php/Analyzer/TupleSymbol/PhpNewSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpNewSymbol.php
@@ -14,25 +14,21 @@ final class PhpNewSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $x, NodeEnvironment $env): PhpNewNode
+    public function __invoke(Tuple $tuple, NodeEnvironment $env): PhpNewNode
     {
-        $tupleCount = count($x);
+        $tupleCount = count($tuple);
         if ($tupleCount < 2) {
-            throw new AnalyzerException(
-                "At least one arguments is required for 'php/new",
-                $x->getStartLocation(),
-                $x->getEndLocation()
-            );
+            throw AnalyzerException::withLocation("At least one arguments is required for 'php/new", $tuple);
         }
 
         $classExpr = $this->analyzer->analyze(
-            $x[1],
+            $tuple[1],
             $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()
         );
         $args = [];
         for ($i = 2; $i < $tupleCount; $i++) {
             $args[] = $this->analyzer->analyze(
-                $x[$i],
+                $tuple[$i],
                 $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()
             );
         }
@@ -41,7 +37,7 @@ final class PhpNewSymbol
             $env,
             $classExpr,
             $args,
-            $x->getStartLocation()
+            $tuple->getStartLocation()
         );
     }
 }

--- a/src/php/Analyzer/TupleSymbol/QuoteSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/QuoteSymbol.php
@@ -11,20 +11,16 @@ use Phel\NodeEnvironment;
 
 final class QuoteSymbol
 {
-    public function __invoke(Tuple $x, NodeEnvironment $env): QuoteNode
+    public function __invoke(Tuple $tuple, NodeEnvironment $env): QuoteNode
     {
-        if (count($x) !== 2) {
-            throw new AnalyzerException(
-                "Exactly one arguments is required for 'quote",
-                $x->getStartLocation(),
-                $x->getEndLocation()
-            );
+        if (count($tuple) !== 2) {
+            throw AnalyzerException::withLocation("Exactly one arguments is required for 'quote", $tuple);
         }
 
         return new QuoteNode(
             $env,
-            $x[1],
-            $x->getStartLocation()
+            $tuple[1],
+            $tuple->getStartLocation()
         );
     }
 }

--- a/src/php/Analyzer/TupleSymbol/RecurSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/RecurSymbol.php
@@ -15,33 +15,24 @@ final class RecurSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $x, NodeEnvironment $env): RecurNode
+    public function __invoke(Tuple $tuple, NodeEnvironment $env): RecurNode
     {
-        $tupleCount = count($x);
+        $tupleCount = count($tuple);
         $frame = $env->getCurrentRecurFrame();
 
-        if (!($x[0] instanceof Symbol && $x[0] == 'recur')) {
-            throw new AnalyzerException(
-                "This is not a 'recur.",
-                $x->getStartLocation(),
-                $x->getEndLocation(),
-            );
+        if (!($tuple[0] instanceof Symbol && $tuple[0] == 'recur')) {
+            throw AnalyzerException::withLocation("This is not a 'recur.", $tuple);
         }
 
         if (!$frame) {
-            throw new AnalyzerException(
-                "Can't call 'recur here",
-                $x[0]->getStartLocation(),
-                $x[0]->getEndLocation()
-            );
+            throw AnalyzerException::withLocation("Can't call 'recur here", $tuple[0]);
         }
 
         if ($tupleCount - 1 !== count($frame->getParams())) {
-            throw new AnalyzerException(
+            throw AnalyzerException::withLocation(
                 "Wrong number of arugments for 'recur. Expected: "
                 . count($frame->getParams()) . ' args, got: ' . ($tupleCount - 1),
-                $x->getStartLocation(),
-                $x->getEndLocation()
+                $tuple
             );
         }
 
@@ -50,7 +41,7 @@ final class RecurSymbol
         $exprs = [];
         for ($i = 1; $i < $tupleCount; $i++) {
             $exprs[] = $this->analyzer->analyze(
-                $x[$i],
+                $tuple[$i],
                 $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()
             );
         }
@@ -59,7 +50,7 @@ final class RecurSymbol
             $env,
             $frame,
             $exprs,
-            $x->getStartLocation()
+            $tuple->getStartLocation()
         );
     }
 }

--- a/src/php/Analyzer/TupleSymbol/ThrowSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ThrowSymbol.php
@@ -14,20 +14,16 @@ final class ThrowSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $x, NodeEnvironment $env): ThrowNode
+    public function __invoke(Tuple $tuple, NodeEnvironment $env): ThrowNode
     {
-        if (count($x) !== 2) {
-            throw new AnalyzerException(
-                "Exact one argument is required for 'throw",
-                $x->getStartLocation(),
-                $x->getEndLocation()
-            );
+        if (count($tuple) !== 2) {
+            throw AnalyzerException::withLocation("Exact one argument is required for 'throw", $tuple);
         }
 
         return new ThrowNode(
             $env,
-            $this->analyzer->analyze($x[1], $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()),
-            $x->getStartLocation()
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()),
+            $tuple->getStartLocation()
         );
     }
 }

--- a/src/php/Analyzer/TupleSymbol/TrySymbol.php
+++ b/src/php/Analyzer/TupleSymbol/TrySymbol.php
@@ -16,9 +16,9 @@ final class TrySymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $x, NodeEnvironment $env): TryNode
+    public function __invoke(Tuple $tuple, NodeEnvironment $env): TryNode
     {
-        $tupleCount = count($x);
+        $tupleCount = count($tuple);
         $state = 'start';
         $body = [];
         $catches = [];
@@ -26,7 +26,7 @@ final class TrySymbol
         $finally = null;
         for ($i = 1; $i < $tupleCount; $i++) {
             /** @var mixed $form */
-            $form = $x[$i];
+            $form = $tuple[$i];
 
             switch ($state) {
                 case 'start':
@@ -48,23 +48,15 @@ final class TrySymbol
                         $state = 'done';
                         $finally = $form;
                     } else {
-                        throw new AnalyzerException("Invalid 'try form", $x->getStartLocation(), $x->getEndLocation());
+                        throw AnalyzerException::withLocation("Invalid 'try form", $tuple);
                     }
                     break;
 
                 case 'done':
-                    throw new AnalyzerException(
-                        "Unexpected form after 'finally",
-                        $x->getStartLocation(),
-                        $x->getEndLocation()
-                    );
+                   throw AnalyzerException::withLocation("Unexpected form after 'finally", $tuple);
 
                 default:
-                    throw new AnalyzerException(
-                        "Unexpected parser state in 'try",
-                        $x->getStartLocation(),
-                        $x->getEndLocation()
-                    );
+                   throw AnalyzerException::withLocation("Unexpected parser state in 'try", $tuple);
             }
         }
 
@@ -83,19 +75,11 @@ final class TrySymbol
             [$_, $type, $name] = $catch;
 
             if (!($type instanceof Symbol)) {
-                throw new AnalyzerException(
-                    "First argument of 'catch must be a Symbol",
-                    $catch->getStartLocation(),
-                    $catch->getEndLocation()
-                );
+                throw AnalyzerException::withLocation("First argument of 'catch must be a Symbol", $catch);
             }
 
             if (!($name instanceof Symbol)) {
-                throw new AnalyzerException(
-                    "Second argument of 'catch must be a Symbol",
-                    $catch->getStartLocation(),
-                    $catch->getEndLocation()
-                );
+                throw AnalyzerException::withLocation("Second argument of 'catch must be a Symbol", $catch);
             }
 
             $exprs = [Symbol::create('do')];
@@ -131,7 +115,7 @@ final class TrySymbol
             $body,
             $catchNodes,
             $finally,
-            $x->getStartLocation()
+            $tuple->getStartLocation()
         );
     }
 

--- a/src/php/Exceptions/PhelCodeException.php
+++ b/src/php/Exceptions/PhelCodeException.php
@@ -13,12 +13,13 @@ class PhelCodeException extends Exception
     private ?SourceLocation $startLocation;
     private ?SourceLocation $endLocation;
 
-    public static function withLocation(string $message, AbstractType $type): self
+    public static function withLocation(string $message, AbstractType $type, ?Exception $nested = null): self
     {
         return new self(
             $message,
             $type->getStartLocation(),
-            $type->getEndLocation()
+            $type->getEndLocation(),
+            $nested
         );
     }
 

--- a/src/php/Exceptions/PhelCodeException.php
+++ b/src/php/Exceptions/PhelCodeException.php
@@ -5,12 +5,22 @@ declare(strict_types=1);
 namespace Phel\Exceptions;
 
 use Exception;
+use Phel\Lang\AbstractType;
 use Phel\Lang\SourceLocation;
 
 class PhelCodeException extends Exception
 {
     private ?SourceLocation $startLocation;
     private ?SourceLocation $endLocation;
+
+    public static function withLocation(string $message, AbstractType $type): self
+    {
+        return new self(
+            $message,
+            $type->getStartLocation(),
+            $type->getEndLocation()
+        );
+    }
 
     public function __construct(
         string $message,

--- a/src/php/Exceptions/ReaderException.php
+++ b/src/php/Exceptions/ReaderException.php
@@ -1,18 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Exceptions;
 
 use Exception;
 use Phel\CodeSnippet;
 use Phel\Lang\SourceLocation;
 
-class ReaderException extends PhelCodeException
+final class ReaderException extends PhelCodeException
 {
-
-    /**
-     * @var CodeSnippet
-     */
-    private $codeSnippet;
+    private CodeSnippet $codeSnippet;
 
     public function __construct(
         string $message,


### PR DESCRIPTION
# Description

I refactor and clean the `Analyzer/TupleSymbol/*.php`.

# Changes

- improving naming (for example: changing `$x` to `$tuple` or `$nodeEnvironment` to `$env`)
- apply extract method refactoring for almost every `else` I saw
- use named constructor (`AnalyzerException::withLocation()`) to help the creation of an `AnalyzerException`
- extract chunks of logic in private methods to keep the level of abstraction easy-peasy to understand
- no functionality was changed