### PR TITLE
Use traits to implement common function among Phel types

### DIFF
--- a/src/php/Lang/ComparableTrait.php
+++ b/src/php/Lang/ComparableTrait.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Phel\Lang;
+
+trait ComparableTrait
+{
+    public function equals($other): bool
+    {
+        return $this == $other;
+    }
+}

--- a/src/php/Lang/CountableTrait.php
+++ b/src/php/Lang/CountableTrait.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Phel\Lang;
+
+trait CountableTrait
+{
+    public function count(): int
+    {
+        return count($this->data);
+    }
+}

--- a/src/php/Lang/HashableTrait.php
+++ b/src/php/Lang/HashableTrait.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Phel\Lang;
+
+trait HashableTrait
+{
+    public function hash(): string
+    {
+        return spl_object_hash($this);
+    }
+}

--- a/src/php/Lang/IterableTrait.php
+++ b/src/php/Lang/IterableTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Phel\Lang;
+
+trait IterableTrait
+{
+    public function current()
+    {
+        return current($this->data);
+    }
+
+    public function key()
+    {
+        return key($this->data);
+    }
+
+    public function next(): void
+    {
+        next($this->data);
+    }
+
+    public function rewind(): void
+    {
+        reset($this->data);
+    }
+
+    public function valid(): bool
+    {
+        return key($this->data) !== null;
+    }
+}

--- a/src/php/Lang/Keyword.php
+++ b/src/php/Lang/Keyword.php
@@ -6,6 +6,7 @@ use Phel\Printer;
 
 class Keyword extends AbstractType implements IIdentical
 {
+    use PrintableTrait;
 
     /**
      * @var string
@@ -35,10 +36,5 @@ class Keyword extends AbstractType implements IIdentical
     public function identical($other): bool
     {
         return $other instanceof Keyword && $this->name == $other->getName();
-    }
-
-    public function __toString(): string
-    {
-        return Printer::readable()->print($this);
     }
 }

--- a/src/php/Lang/PhelArray.php
+++ b/src/php/Lang/PhelArray.php
@@ -13,6 +13,7 @@ final class PhelArray extends AbstractType implements ArrayAccess, Countable, It
 {
     use HashableTrait;
     use PrintableTrait;
+    use CountableTrait;
 
     private array $data;
 
@@ -67,11 +68,6 @@ final class PhelArray extends AbstractType implements ArrayAccess, Countable, It
     public function offsetGet($offset)
     {
         return $this->data[$offset] ?? null;
-    }
-
-    public function count(): int
-    {
-        return count($this->data);
     }
 
     public function current()

--- a/src/php/Lang/PhelArray.php
+++ b/src/php/Lang/PhelArray.php
@@ -15,6 +15,7 @@ final class PhelArray extends AbstractType implements ArrayAccess, Countable, It
     use PrintableTrait;
     use CountableTrait;
     use IterableTrait;
+    use ComparableTrait;
 
     private array $data;
 
@@ -69,11 +70,6 @@ final class PhelArray extends AbstractType implements ArrayAccess, Countable, It
     public function offsetGet($offset)
     {
         return $this->data[$offset] ?? null;
-    }
-
-    public function equals($other): bool
-    {
-        return $this == $other;
     }
 
     public function slice(int $offset = 0, ?int $length = null): ISlice

--- a/src/php/Lang/PhelArray.php
+++ b/src/php/Lang/PhelArray.php
@@ -14,6 +14,7 @@ final class PhelArray extends AbstractType implements ArrayAccess, Countable, It
     use HashableTrait;
     use PrintableTrait;
     use CountableTrait;
+    use IterableTrait;
 
     private array $data;
 
@@ -68,31 +69,6 @@ final class PhelArray extends AbstractType implements ArrayAccess, Countable, It
     public function offsetGet($offset)
     {
         return $this->data[$offset] ?? null;
-    }
-
-    public function current()
-    {
-        return current($this->data);
-    }
-
-    public function key()
-    {
-        return key($this->data);
-    }
-
-    public function next()
-    {
-        next($this->data);
-    }
-
-    public function rewind()
-    {
-        reset($this->data);
-    }
-
-    public function valid()
-    {
-        return key($this->data) !== null;
     }
 
     public function equals($other): bool

--- a/src/php/Lang/PhelArray.php
+++ b/src/php/Lang/PhelArray.php
@@ -8,11 +8,11 @@ use ArrayAccess;
 use Countable;
 use InvalidArgumentException;
 use Iterator;
-use Phel\Printer;
 
 final class PhelArray extends AbstractType implements ArrayAccess, Countable, Iterator, ICons, ISlice, ICdr, IRest, IPop, IRemove, IPush, IConcat
 {
     use HashableTrait;
+    use PrintableTrait;
 
     private array $data;
 
@@ -158,10 +158,5 @@ final class PhelArray extends AbstractType implements ArrayAccess, Countable, It
             $this->data[] = $x;
         }
         return $this;
-    }
-
-    public function __toString(): string
-    {
-        return Printer::readable()->print($this);
     }
 }

--- a/src/php/Lang/PhelArray.php
+++ b/src/php/Lang/PhelArray.php
@@ -12,6 +12,8 @@ use Phel\Printer;
 
 final class PhelArray extends AbstractType implements ArrayAccess, Countable, Iterator, ICons, ISlice, ICdr, IRest, IPop, IRemove, IPush, IConcat
 {
+    use HashableTrait;
+
     private array $data;
 
     /**
@@ -95,11 +97,6 @@ final class PhelArray extends AbstractType implements ArrayAccess, Countable, It
     public function valid()
     {
         return key($this->data) !== null;
-    }
-
-    public function hash(): string
-    {
-        return spl_object_hash($this);
     }
 
     public function equals($other): bool

--- a/src/php/Lang/PrintableTrait.php
+++ b/src/php/Lang/PrintableTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Phel\Lang;
+
+use Phel\Printer;
+
+trait PrintableTrait
+{
+    public function __toString(): string
+    {
+        return Printer::readable()->print($this);
+    }
+}

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -8,6 +8,8 @@ use Phel\Printer;
 
 final class Symbol extends AbstractType implements IIdentical
 {
+    use HashableTrait;
+
     private static int $symGenCounter = 1;
 
     private ?string $namespace;
@@ -68,11 +70,6 @@ final class Symbol extends AbstractType implements IIdentical
     public static function resetGen(): void
     {
         self::$symGenCounter = 1;
-    }
-
-    public function hash(): string
-    {
-        return $this->getName();
     }
 
     public function equals($other): bool

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Phel\Lang;
 
-use Phel\Printer;
-
 final class Symbol extends AbstractType implements IIdentical
 {
     use HashableTrait;
+    use PrintableTrait;
 
     private static int $symGenCounter = 1;
 
@@ -55,11 +54,6 @@ final class Symbol extends AbstractType implements IIdentical
         }
 
         return $this->name;
-    }
-
-    public function __toString(): string
-    {
-        return Printer::readable()->print($this);
     }
 
     public static function gen(string $prefix = '__phel_'): Symbol

--- a/src/php/Lang/Table.php
+++ b/src/php/Lang/Table.php
@@ -14,6 +14,7 @@ class Table extends AbstractType implements ArrayAccess, Countable, Iterator
     use HashableTrait;
     use PrintableTrait;
     use CountableTrait;
+    use IterableTrait;
 
     protected array $data = [];
 
@@ -82,11 +83,6 @@ class Table extends AbstractType implements ArrayAccess, Countable, Iterator
         return $this->data[$hash] ?? null;
     }
 
-    public function current()
-    {
-        return current($this->data);
-    }
-
     /**
      * @return mixed|null
      */
@@ -99,21 +95,6 @@ class Table extends AbstractType implements ArrayAccess, Countable, Iterator
         }
 
         return null;
-    }
-
-    public function next(): void
-    {
-        next($this->data);
-    }
-
-    public function rewind(): void
-    {
-        reset($this->data);
-    }
-
-    public function valid(): bool
-    {
-        return key($this->data) !== null;
     }
 
     public function equals($other): bool

--- a/src/php/Lang/Table.php
+++ b/src/php/Lang/Table.php
@@ -13,6 +13,7 @@ class Table extends AbstractType implements ArrayAccess, Countable, Iterator
 {
     use HashableTrait;
     use PrintableTrait;
+    use CountableTrait;
 
     protected array $data = [];
 
@@ -79,11 +80,6 @@ class Table extends AbstractType implements ArrayAccess, Countable, Iterator
         $hash = $this->offsetHash($offset);
 
         return $this->data[$hash] ?? null;
-    }
-
-    public function count(): int
-    {
-        return count($this->data);
     }
 
     public function current()

--- a/src/php/Lang/Table.php
+++ b/src/php/Lang/Table.php
@@ -8,11 +8,11 @@ use ArrayAccess;
 use Countable;
 use Exception;
 use Iterator;
-use Phel\Printer;
 
 class Table extends AbstractType implements ArrayAccess, Countable, Iterator
 {
     use HashableTrait;
+    use PrintableTrait;
 
     protected array $data = [];
 
@@ -154,10 +154,5 @@ class Table extends AbstractType implements ArrayAccess, Countable, Iterator
         }
 
         return (string) $offset;
-    }
-
-    public function __toString(): string
-    {
-        return Printer::readable()->print($this);
     }
 }

--- a/src/php/Lang/Table.php
+++ b/src/php/Lang/Table.php
@@ -15,6 +15,7 @@ class Table extends AbstractType implements ArrayAccess, Countable, Iterator
     use PrintableTrait;
     use CountableTrait;
     use IterableTrait;
+    use ComparableTrait;
 
     protected array $data = [];
 
@@ -95,11 +96,6 @@ class Table extends AbstractType implements ArrayAccess, Countable, Iterator
         }
 
         return null;
-    }
-
-    public function equals($other): bool
-    {
-        return $this == $other;
     }
 
     public function toKeyValueList(): array

--- a/src/php/Lang/Table.php
+++ b/src/php/Lang/Table.php
@@ -12,6 +12,8 @@ use Phel\Printer;
 
 class Table extends AbstractType implements ArrayAccess, Countable, Iterator
 {
+    use HashableTrait;
+
     protected array $data = [];
 
     protected array $keys = [];
@@ -116,11 +118,6 @@ class Table extends AbstractType implements ArrayAccess, Countable, Iterator
     public function valid(): bool
     {
         return key($this->data) !== null;
-    }
-
-    public function hash(): string
-    {
-        return spl_object_hash($this);
     }
 
     public function equals($other): bool

--- a/src/php/Lang/Tuple.php
+++ b/src/php/Lang/Tuple.php
@@ -14,6 +14,7 @@ class Tuple extends AbstractType implements ArrayAccess, Countable, Iterator, IS
     use HashableTrait;
     use PrintableTrait;
     use CountableTrait;
+    use IterableTrait;
 
     private array $data;
 
@@ -75,31 +76,6 @@ class Tuple extends AbstractType implements ArrayAccess, Countable, Iterator, IS
     public function isUsingBracket(): bool
     {
         return $this->usingBracket;
-    }
-
-    public function current()
-    {
-        return current($this->data);
-    }
-
-    public function key()
-    {
-        return key($this->data);
-    }
-
-    public function next()
-    {
-        next($this->data);
-    }
-
-    public function rewind()
-    {
-        reset($this->data);
-    }
-
-    public function valid()
-    {
-        return key($this->data) !== null;
     }
 
     /**

--- a/src/php/Lang/Tuple.php
+++ b/src/php/Lang/Tuple.php
@@ -13,8 +13,10 @@ class Tuple extends AbstractType implements ArrayAccess, Countable, Iterator, IS
 {
     use HashableTrait;
     use PrintableTrait;
+    use CountableTrait;
 
     private array $data;
+
     private bool $usingBracket;
 
     /**
@@ -68,11 +70,6 @@ class Tuple extends AbstractType implements ArrayAccess, Countable, Iterator, IS
     public function offsetGet($offset)
     {
         return $this->data[$offset] ?? null;
-    }
-
-    public function count()
-    {
-        return count($this->data);
     }
 
     public function isUsingBracket(): bool

--- a/src/php/Lang/Tuple.php
+++ b/src/php/Lang/Tuple.php
@@ -12,6 +12,8 @@ use Phel\Printer;
 
 class Tuple extends AbstractType implements ArrayAccess, Countable, Iterator, ISlice, ICons, ICdr, IRest, IPush, IConcat
 {
+    use HashableTrait;
+
     private array $data;
     private bool $usingBracket;
 
@@ -145,11 +147,6 @@ class Tuple extends AbstractType implements ArrayAccess, Countable, Iterator, IS
     public function cons($x): ICons
     {
         return new Tuple([$x, ...$this->data], $this->isUsingBracket());
-    }
-
-    public function hash(): string
-    {
-        return spl_object_hash($this);
     }
 
     public function equals($other): bool

--- a/src/php/Lang/Tuple.php
+++ b/src/php/Lang/Tuple.php
@@ -15,6 +15,7 @@ class Tuple extends AbstractType implements ArrayAccess, Countable, Iterator, IS
     use PrintableTrait;
     use CountableTrait;
     use IterableTrait;
+    use ComparableTrait;
 
     private array $data;
 
@@ -120,11 +121,6 @@ class Tuple extends AbstractType implements ArrayAccess, Countable, Iterator, IS
     public function cons($x): ICons
     {
         return new Tuple([$x, ...$this->data], $this->isUsingBracket());
-    }
-
-    public function equals($other): bool
-    {
-        return $this == $other;
     }
 
     public function cdr(): ?ICdr

--- a/src/php/Lang/Tuple.php
+++ b/src/php/Lang/Tuple.php
@@ -8,11 +8,11 @@ use ArrayAccess;
 use Countable;
 use InvalidArgumentException;
 use Iterator;
-use Phel\Printer;
 
 class Tuple extends AbstractType implements ArrayAccess, Countable, Iterator, ISlice, ICons, ICdr, IRest, IPush, IConcat
 {
     use HashableTrait;
+    use PrintableTrait;
 
     private array $data;
     private bool $usingBracket;
@@ -189,10 +189,5 @@ class Tuple extends AbstractType implements ArrayAccess, Countable, Iterator, IS
     public function toArray(): array
     {
         return $this->data;
-    }
-
-    public function __toString(): string
-    {
-        return Printer::readable()->print($this);
     }
 }


### PR DESCRIPTION
# Description

Closes #71 by refactoring classes inheriting from `AbstractType` in order to factorize the code with traits, and to make it more concise, so it will be also more readable and maintainable. Since this is only refactoring, it should keep the exact same behavior that Phel previously had.

# Changes

- Create traits
  - `HashableTrait`
  - `PrintableTrait`
  - `CountableTrait`
  - `IterableTrait`
  - `ComparableTrait`
- Use those traits in Phel Types
  - `Keyword`
  - `PhelArray`
  - `Symbol`
  - `Table`
  - `Tuple`