### PR TITLE
Fixed reduce on sequences containing a nil value

### DIFF
--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -807,7 +807,7 @@ collection in map"))
   (apply concat @[] (apply map f xs)))
 
 (defn reduce [f init xs]
-  (if (nil? (first xs))
+  (if (= (count xs) 0)
     init
     (recur f (f init (first xs)) (next xs))))
 

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -375,9 +375,11 @@
 (assert (= @[] (mapcat identity @[])) "mapcat on empty array")
 
 (assert (= "abc" (reduce str "" ["a" "b" "c"])) "reduce three elements tuple")
+(assert (= "abc" (reduce str "" [nil "a" "b" "c"])) "reduce tuple containing a nil value")
 (assert (= "x" (reduce str "x" [])) "reduce empty tuple")
 
 (assert (= "abc" (reduce2 str ["a" "b" "c"])) "reduce2 three elements tuple")
+(assert (= "abc" (reduce2 str [nil "a" "b" "c"])) "reduce2 tuple containing a nil value")
 (assert (= "a" (reduce2 str ["a"])) "reduce2 one element tuple")
 (assert (= nil (reduce2 str [])) "reduce2 empty tuple")
 


### PR DESCRIPTION
# Description

This is a bugfix to allow reduce to iterate over all values either they are `nil` or not since skipping those values should be handled by the user. Closes #80 

# Changes

- Replaced the pre-recursion check on the `first` element of the sequence parameter being `nil` to a `count` of this sequence being `> 0`.
- Added tests to prevent regression.