### PR TITLE
Add test ColorStyle & ReadLine classes

### DIFF
--- a/src/php/Commands/Repl/ColorStyle.php
+++ b/src/php/Commands/Repl/ColorStyle.php
@@ -26,6 +26,11 @@ final class ColorStyle
         $this->styles = $styles;
     }
 
+    public function green(string $str): string
+    {
+        return $this->color($str, 'green');
+    }
+
     public function yellow(string $str): string
     {
         return $this->color($str, 'yellow');

--- a/tests/php/Commands/Repl/ColorStyleTest.php
+++ b/tests/php/Commands/Repl/ColorStyleTest.php
@@ -20,4 +20,15 @@ final class ColorStyleTest extends TestCase
             $style->color($anyText, $color)
         );
     }
+
+    public function testDefaultColors(): void
+    {
+        $style = ColorStyle::withStyles();
+        $anyText = 'any text';
+
+        self::assertSame('[0;32many text[0m', $style->green($anyText));
+        self::assertSame('[31;31many text[0m', $style->red($anyText));
+        self::assertSame('[33;33many text[0m', $style->yellow($anyText));
+        self::assertSame('[33;34many text[0m', $style->blue($anyText));
+    }
 }

--- a/tests/php/Commands/Repl/ReadlineTest.php
+++ b/tests/php/Commands/Repl/ReadlineTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Commands\Repl;
+
+use PHPUnit\Framework\TestCase;
+
+class ReadlineTest extends TestCase
+{
+    public function testLineAddedToHistory(): void
+    {
+        $readLine = new Readline('');
+
+        $readLine->addHistory('first line');
+        $readLine->addHistory('second line');
+
+        self::assertSame(
+            ['first line', 'second line'],
+            $readLine->listHistory()
+        );
+    }
+
+    public function testHistoryClearResultIsEmpty(): void
+    {
+        $readLine = new Readline('');
+
+        $readLine->addHistory('first line');
+        $readLine->addHistory('second line');
+
+        $readLine->clearHistory();
+
+        self::assertSame([], $readLine->listHistory());
+    }
+}

--- a/tests/php/Commands/Repl/ReadlineTest.php
+++ b/tests/php/Commands/Repl/ReadlineTest.php
@@ -6,7 +6,7 @@ namespace Phel\Commands\Repl;
 
 use PHPUnit\Framework\TestCase;
 
-class ReadlineTest extends TestCase
+final class ReadlineTest extends TestCase
 {
     public function testLineAddedToHistory(): void
     {


### PR DESCRIPTION
# Description

I cannot test the methods `readHistory()`. `readline()` & `redisplay()`.
Probably I need to create some interface...

# Changes

- Add `green` method in `ColorStyle`.
- Update `ColorStyleTest`.
- Create `ReadLineTest`.