### PR TITLE
fix set first and second

### DIFF
--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -254,7 +254,7 @@ This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`"
 (defn second
   "Returns the second element of an indexed sequence or nil."
   [xs]
-  (php/aget xs 1))
+  (first (next xs)))
 
 (defn rest
   "Returns the sequence of elements after the first element. If there are no

--- a/src/php/Lang/Set.php
+++ b/src/php/Lang/Set.php
@@ -73,6 +73,10 @@ class Set extends AbstractType implements Countable, Iterator, ISeq, ICons, IPus
 
     public function first()
     {
+        if (count($this->data) == 0) {
+            return null;
+        }
+
         $this->rewind();
         return $this->current();
     }

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -607,6 +607,12 @@
       s2 (push s1 2)]
   (assert (= (set 1 2) s2) "set push existing value"))
 
+(assert (= 1 (first (set 1 2 3))) "set first element")
+(assert (= nil (first (set))) "set first element from empty set")
+(assert (= 2 (second (set 1 2 3))) "set second element")
+(assert (= nil (second (set))) "set second element from empty set")
+(assert (= nil (second (set 1))) "set second element from 1-ary set")
+
 (assert (= (set 1 2 0 3) (concat (set 1 2) @[0 3])) "set concat array")
 (assert (= (set 1 2 0 3) (concat (set 1 2) @[0 1 2 3])) "set concat array with common values")
 (assert (= (set 1 2 0) (concat (set 1 2) (set 0 1))) "set concat")


### PR DESCRIPTION
# Description

`(first (set))` should return `nil` but return `false` instead. Also `second` cannot be used on a set since it uses `php/aget`.

# Changes

- Added set tests
- Fixed `first` on empty set
- Updating `second` to use `first` and `next` to be compatible with sets