### PR TITLE
Add tests to AnalyzeTuple class

### DIFF
--- a/tests/php/Analyzer/AnalyzeTupleTest.php
+++ b/tests/php/Analyzer/AnalyzeTupleTest.php
@@ -46,7 +46,7 @@ final class AnalyzeTupleTest extends TestCase
         self::assertInstanceOf(DefNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
     }
 
-    public function testSymbolWithNameNS(): void
+    public function testSymbolWithNameNs(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_NS), Symbol::create('def-ns'));
         self::assertInstanceOf(NsNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));

--- a/tests/php/Analyzer/AnalyzeTupleTest.php
+++ b/tests/php/Analyzer/AnalyzeTupleTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Analyzer;
+
+use Phel\Analyzer;
+use Phel\Ast\ApplyNode;
+use Phel\Ast\DefNode;
+use Phel\Ast\DefStructNode;
+use Phel\Ast\DoNode;
+use Phel\Ast\FnNode;
+use Phel\Ast\ForeachNode;
+use Phel\Ast\IfNode;
+use Phel\Ast\LetNode;
+use Phel\Ast\NsNode;
+use Phel\Ast\PhpArrayGetNode;
+use Phel\Ast\PhpArrayPushNode;
+use Phel\Ast\PhpArraySetNode;
+use Phel\Ast\PhpArrayUnsetNode;
+use Phel\Ast\PhpNewNode;
+use Phel\Ast\PhpObjectCallNode;
+use Phel\Ast\QuoteNode;
+use Phel\Ast\RecurNode;
+use Phel\Ast\ThrowNode;
+use Phel\Ast\TryNode;
+use Phel\GlobalEnvironment;
+use Phel\Lang\Symbol;
+use Phel\Lang\Tuple;
+use Phel\NodeEnvironment;
+use Phel\RecurFrame;
+use PHPUnit\Framework\TestCase;
+
+final class AnalyzeTupleTest extends TestCase
+{
+    /**
+     * @dataProvider tupleProvider
+     */
+    public function testSymbols(string $expected, Tuple $tuple): void
+    {
+        $tupleAnalyzer = new AnalyzeTuple(new Analyzer(new GlobalEnvironment()));
+        self::assertInstanceOf($expected, $tupleAnalyzer($tuple, NodeEnvironment::empty()));
+    }
+
+    public function tupleProvider(): array
+    {
+        return [
+            Symbol::NAME_DEF => [
+                DefNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_DEF), Symbol::create('increment'), 'inc')
+            ],
+            Symbol::NAME_NS => [
+                NsNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_NS), Symbol::create('def-ns'))
+            ],
+            Symbol::NAME_FN => [
+                FnNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_FN), Tuple::create())
+            ],
+            Symbol::NAME_QUOTE => [
+                QuoteNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_QUOTE), 'any text')
+            ],
+            Symbol::NAME_DO => [
+                DoNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_DO), 1)
+            ],
+            Symbol::NAME_IF => [
+                IfNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_IF), true, true)
+            ],
+            Symbol::NAME_APPLY => [
+                ApplyNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_APPLY), '+', Tuple::create(''))
+            ],
+            Symbol::NAME_LET => [
+                LetNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_LET), Tuple::create(), Tuple::create())
+            ],
+            Symbol::NAME_PHP_NEW => [PhpNewNode::class, Tuple::create(Symbol::create(Symbol::NAME_PHP_NEW), '')],
+            Symbol::NAME_PHP_OBJECT_CALL => [
+                PhpObjectCallNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_PHP_OBJECT_CALL), '', Symbol::create(''))
+            ],
+            Symbol::NAME_PHP_OBJECT_STATIC_CALL => [
+                PhpObjectCallNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL), '', Symbol::create(''))
+            ],
+            Symbol::NAME_PHP_ARRAY_GET => [
+                PhpArrayGetNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_GET))
+            ],
+            Symbol::NAME_PHP_ARRAY_SET => [
+                PhpArraySetNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_SET))
+            ],
+            Symbol::NAME_PHP_ARRAY_PUSH => [
+                PhpArrayPushNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_PUSH))
+            ],
+            Symbol::NAME_PHP_ARRAY_UNSET => [
+                PhpArrayUnsetNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_UNSET))
+            ],
+            Symbol::NAME_TRY => [
+                TryNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_TRY))
+            ],
+            Symbol::NAME_THROW => [
+                ThrowNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_THROW), '')
+            ],
+            Symbol::NAME_LOOP => [
+                LetNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_LOOP), Tuple::create(), Tuple::create())
+            ],
+            Symbol::NAME_FOREACH => [
+                ForeachNode::class,
+                Tuple::create(
+                    Symbol::create(Symbol::NAME_FOREACH),
+                    Tuple::create(Symbol::create(''), Tuple::create()),
+                    Tuple::create()
+                )
+            ],
+            Symbol::NAME_DEF_STRUCT => [
+                DefStructNode::class,
+                Tuple::create(Symbol::create(Symbol::NAME_DEF_STRUCT), Symbol::create(''), Tuple::create())
+            ],
+        ];
+    }
+
+    public function testRecurSymbol(): void
+    {
+        $recurFrames = [new RecurFrame([Symbol::create(Symbol::NAME_FOREACH)])];
+        $nodeEnv = new NodeEnvironment([], NodeEnvironment::CTX_STMT, [], $recurFrames);
+        $tupleAnalyzer = new AnalyzeTuple(new Analyzer(new GlobalEnvironment()));
+
+        self::assertInstanceOf(
+            RecurNode::class,
+            $tupleAnalyzer(Tuple::create(Symbol::create(Symbol::NAME_RECUR), 1), $nodeEnv)
+        );
+    }
+}

--- a/tests/php/Analyzer/AnalyzeTupleTest.php
+++ b/tests/php/Analyzer/AnalyzeTupleTest.php
@@ -33,111 +33,160 @@ use PHPUnit\Framework\TestCase;
 
 final class AnalyzeTupleTest extends TestCase
 {
-    /**
-     * @dataProvider tupleProvider
-     */
-    public function testSymbols(string $expected, Tuple $tuple): void
+    private AnalyzeTuple $tupleAnalyzer;
+
+    public function setUp(): void
     {
-        $tupleAnalyzer = new AnalyzeTuple(new Analyzer(new GlobalEnvironment()));
-        self::assertInstanceOf($expected, $tupleAnalyzer($tuple, NodeEnvironment::empty()));
+        $this->tupleAnalyzer = new AnalyzeTuple(new Analyzer(new GlobalEnvironment()));
     }
 
-    public function tupleProvider(): array
+    public function testSymbolWithNameDef(): void
     {
-        return [
-            Symbol::NAME_DEF => [
-                DefNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_DEF), Symbol::create('increment'), 'inc')
-            ],
-            Symbol::NAME_NS => [
-                NsNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_NS), Symbol::create('def-ns'))
-            ],
-            Symbol::NAME_FN => [
-                FnNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_FN), Tuple::create())
-            ],
-            Symbol::NAME_QUOTE => [
-                QuoteNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_QUOTE), 'any text')
-            ],
-            Symbol::NAME_DO => [
-                DoNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_DO), 1)
-            ],
-            Symbol::NAME_IF => [
-                IfNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_IF), true, true)
-            ],
-            Symbol::NAME_APPLY => [
-                ApplyNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_APPLY), '+', Tuple::create(''))
-            ],
-            Symbol::NAME_LET => [
-                LetNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_LET), Tuple::create(), Tuple::create())
-            ],
-            Symbol::NAME_PHP_NEW => [PhpNewNode::class, Tuple::create(Symbol::create(Symbol::NAME_PHP_NEW), '')],
-            Symbol::NAME_PHP_OBJECT_CALL => [
-                PhpObjectCallNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_PHP_OBJECT_CALL), '', Symbol::create(''))
-            ],
-            Symbol::NAME_PHP_OBJECT_STATIC_CALL => [
-                PhpObjectCallNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL), '', Symbol::create(''))
-            ],
-            Symbol::NAME_PHP_ARRAY_GET => [
-                PhpArrayGetNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_GET))
-            ],
-            Symbol::NAME_PHP_ARRAY_SET => [
-                PhpArraySetNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_SET))
-            ],
-            Symbol::NAME_PHP_ARRAY_PUSH => [
-                PhpArrayPushNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_PUSH))
-            ],
-            Symbol::NAME_PHP_ARRAY_UNSET => [
-                PhpArrayUnsetNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_UNSET))
-            ],
-            Symbol::NAME_TRY => [
-                TryNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_TRY))
-            ],
-            Symbol::NAME_THROW => [
-                ThrowNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_THROW), '')
-            ],
-            Symbol::NAME_LOOP => [
-                LetNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_LOOP), Tuple::create(), Tuple::create())
-            ],
-            Symbol::NAME_FOREACH => [
-                ForeachNode::class,
-                Tuple::create(
-                    Symbol::create(Symbol::NAME_FOREACH),
-                    Tuple::create(Symbol::create(''), Tuple::create()),
-                    Tuple::create()
-                )
-            ],
-            Symbol::NAME_DEF_STRUCT => [
-                DefStructNode::class,
-                Tuple::create(Symbol::create(Symbol::NAME_DEF_STRUCT), Symbol::create(''), Tuple::create())
-            ],
-        ];
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_DEF), Symbol::create('increment'), 'inc');
+        self::assertInstanceOf(DefNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
     }
 
-    public function testRecurSymbol(): void
+    public function testSymbolWithNameNS(): void
     {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_NS), Symbol::create('def-ns'));
+        self::assertInstanceOf(NsNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+    }
+
+    public function testSymbolWithNameFn(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_FN), Tuple::create());
+        self::assertInstanceOf(FnNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+    }
+
+    public function testSymbolWithNameQuote(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_QUOTE), 'any text');
+        self::assertInstanceOf(QuoteNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+    }
+
+    public function testSymbolWithNameDo(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_DO), 1);
+        self::assertInstanceOf(DoNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+    }
+
+    public function testSymbolWithNameIf(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_IF), true, true);
+        self::assertInstanceOf(IfNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+    }
+
+    public function testSymbolWithNameApply(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_APPLY), '+', Tuple::create(''));
+        self::assertInstanceOf(ApplyNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+    }
+
+    public function testSymbolWithNameLet(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_LET), Tuple::create(), Tuple::create());
+        self::assertInstanceOf(LetNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+    }
+
+    public function testSymbolWithNamePhpNew(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_NEW), '');
+        self::assertInstanceOf(PhpNewNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+    }
+
+    public function testSymbolWithNamePhpObjectCall(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_OBJECT_CALL), '', Symbol::create(''));
+        self::assertInstanceOf(
+            PhpObjectCallNode::class,
+            $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty())
+        );
+    }
+
+    public function testSymbolWithNamePhpObjectStaticCall(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL), '', Symbol::create(''));
+        self::assertInstanceOf(
+            PhpObjectCallNode::class,
+            $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty())
+        );
+    }
+
+    public function testSymbolWithNamePhpArrayGet(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_GET));
+        self::assertInstanceOf(
+            PhpArrayGetNode::class,
+            $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty())
+        );
+    }
+
+    public function testSymbolWithNamePhpArraySet(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_SET));
+        self::assertInstanceOf(
+            PhpArraySetNode::class,
+            $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty())
+        );
+    }
+
+    public function testSymbolWithNamePhpArrayPush(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_PUSH));
+        self::assertInstanceOf(
+            PhpArrayPushNode::class,
+            $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty())
+        );
+    }
+
+    public function testSymbolWithNamePhpArrayUnset(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_UNSET));
+        self::assertInstanceOf(
+            PhpArrayUnsetNode::class,
+            $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty())
+        );
+    }
+
+    public function testSymbolWithNameRecur(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_RECUR), 1);
         $recurFrames = [new RecurFrame([Symbol::create(Symbol::NAME_FOREACH)])];
         $nodeEnv = new NodeEnvironment([], NodeEnvironment::CTX_STMT, [], $recurFrames);
-        $tupleAnalyzer = new AnalyzeTuple(new Analyzer(new GlobalEnvironment()));
+        self::assertInstanceOf(RecurNode::class, $this->tupleAnalyzer->__invoke($tuple, $nodeEnv));
+    }
 
-        self::assertInstanceOf(
-            RecurNode::class,
-            $tupleAnalyzer(Tuple::create(Symbol::create(Symbol::NAME_RECUR), 1), $nodeEnv)
+    public function testSymbolWithNameTry(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_TRY));
+        self::assertInstanceOf(TryNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+    }
+
+    public function testSymbolWithNameThrow(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_THROW), '');
+        self::assertInstanceOf(ThrowNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+    }
+
+    public function testSymbolWithNameLoop(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_LOOP), Tuple::create(), Tuple::create());
+        self::assertInstanceOf(LetNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+    }
+
+    public function testSymbolWithNameForeach(): void
+    {
+        $tuple = Tuple::create(
+            Symbol::create(Symbol::NAME_FOREACH),
+            Tuple::create(Symbol::create(''), Tuple::create()),
+            Tuple::create()
         );
+        self::assertInstanceOf(ForeachNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+    }
+
+    public function testSymbolWithNameDefStruct(): void
+    {
+        $tuple = Tuple::create(Symbol::create(Symbol::NAME_DEF_STRUCT), Symbol::create(''), Tuple::create());
+        self::assertInstanceOf(DefStructNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
     }
 }


### PR DESCRIPTION
# Description

- Create `AnalyzeTupleTest` class.
    - The purpose of this test is to check if the analyze factory works and depending on the input, it returns the correct class.

**PS:** I was not able to test the `default` switch case.