### PR TITLE
Define PhelTest namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Phel\\": "tests/php"
+            "PhelTest\\": "tests/php"
         }
     },
     "scripts": {

--- a/tests/php/Analyzer/AnalyzeTupleTest.php
+++ b/tests/php/Analyzer/AnalyzeTupleTest.php
@@ -2,9 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Phel\Analyzer;
+namespace PhelTest\Analyzer;
 
 use Phel\Analyzer;
+use Phel\Analyzer\AnalyzeTuple;
 use Phel\Ast\ApplyNode;
 use Phel\Ast\DefNode;
 use Phel\Ast\DefStructNode;

--- a/tests/php/Analyzer/TupleSymbol/QuoteSymbolTest.php
+++ b/tests/php/Analyzer/TupleSymbol/QuoteSymbolTest.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Phel\Analyzer\TupleSymbol;
+namespace PhelTest\Analyzer\TupleSymbol;
 
+use Phel\Analyzer\TupleSymbol\QuoteSymbol;
 use Phel\Exceptions\PhelCodeException;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;

--- a/tests/php/Commands/Repl/ColorStyleTest.php
+++ b/tests/php/Commands/Repl/ColorStyleTest.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Phel\Commands\Repl;
+namespace PhelTest\Commands\Repl;
 
+use Phel\Commands\Repl\ColorStyle;
 use PHPUnit\Framework\TestCase;
 
 final class ColorStyleTest extends TestCase

--- a/tests/php/Commands/Repl/ReadlineTest.php
+++ b/tests/php/Commands/Repl/ReadlineTest.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Phel\Commands\Repl;
+namespace PhelTest\Commands\Repl;
 
+use Phel\Commands\Repl\Readline;
 use PHPUnit\Framework\TestCase;
 
 final class ReadlineTest extends TestCase

--- a/tests/php/Commands/RunCommandTest.php
+++ b/tests/php/Commands/RunCommandTest.php
@@ -1,14 +1,17 @@
 <?php
 
-namespace Phel\Commands;
+declare(strict_types=1);
 
+namespace PhelTest\Commands;
+
+use Phel\Commands\RunCommand;
 use Phel\Runtime;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class RunCommandTest extends TestCase
+final class RunCommandTest extends TestCase
 {
-    public function testRunByNamespace()
+    public function testRunByNamespace(): void
     {
         $runtime = Runtime::initializeNew();
         $runtime->addPath('test\\', [__DIR__ . '/Fixtures']);
@@ -19,7 +22,7 @@ class RunCommandTest extends TestCase
         $run->run(__DIR__, 'test\\test-script');
     }
 
-    public function testRunByFilename()
+    public function testRunByFilename(): void
     {
         $runtime = Runtime::initializeNew();
         $runtime->addPath('test\\', [__DIR__ . '/Fixtures']);
@@ -30,7 +33,7 @@ class RunCommandTest extends TestCase
         $run->run(__DIR__, __DIR__ . '/Fixtures/test-script.phel');
     }
 
-    public function testCannotParseFile()
+    public function testCannotParseFile(): void
     {
         $filename = __DIR__ . '/Fixtures/test-script-not-parsable.phel';
         $this->expectException(RuntimeException::class);
@@ -40,7 +43,7 @@ class RunCommandTest extends TestCase
         $run->run(__DIR__, $filename);
     }
 
-    public function testCannotReadFile()
+    public function testCannotReadFile(): void
     {
         $filename = __DIR__ . '/Fixtures/this-file-does-not-exist.phel';
         $this->expectException(RuntimeException::class);
@@ -50,7 +53,7 @@ class RunCommandTest extends TestCase
         $run->run(__DIR__, $filename);
     }
 
-    public function testFileWithoutNs()
+    public function testFileWithoutNs(): void
     {
         $filename = __DIR__ . '/Fixtures/test-script-without-ns.phel';
         $this->expectException(RuntimeException::class);

--- a/tests/php/Commands/TestCommandTest.php
+++ b/tests/php/Commands/TestCommandTest.php
@@ -1,13 +1,16 @@
 <?php
 
-namespace Phel\Commands;
+declare(strict_types=1);
 
+namespace PhelTest\Commands;
+
+use Phel\Commands\TestCommand;
 use Phel\Runtime;
 use PHPUnit\Framework\TestCase;
 
-class TestCommandTest extends TestCase
+final class TestCommandTest extends TestCase
 {
-    public function testAllInProject()
+    public function testAllInProject(): void
     {
         $runtime = Runtime::initializeNew();
         $runtime->addPath('test-cmd-project-success\\', [__DIR__ . '/Fixtures/test-cmd-project-success/tests']);
@@ -22,7 +25,7 @@ class TestCommandTest extends TestCase
         );
     }
 
-    public function testOneFileInProject()
+    public function testOneFileInProject(): void
     {
         $runtime = Runtime::initializeNew();
         $runtime->addPath('test-cmd-project-success\\', [__DIR__ . '/Fixtures/test-cmd-project-success/tests']);
@@ -40,7 +43,7 @@ class TestCommandTest extends TestCase
         );
     }
 
-    public function testAllInFailedProject()
+    public function testAllInFailedProject(): void
     {
         $runtime = Runtime::initializeNew();
         $runtime->addPath('test-cmd-project-failure\\', [__DIR__ . '/Fixtures/test-cmd-project-failure/tests']);

--- a/tests/php/Lang/TableTest.php
+++ b/tests/php/Lang/TableTest.php
@@ -1,14 +1,17 @@
 <?php
 
-namespace Phel\Lang;
+declare(strict_types=1);
 
+namespace PhelTest\Lang;
+
+use Phel\Lang\Table;
 use PHPUnit\Framework\TestCase;
 
-class TableTest extends TestCase
+final class TableTest extends TestCase
 {
-    public function testNumberZeroAsValue()
+    public function testNumberZeroAsValue(): void
     {
-        $t = Table::fromKVs('a', 0);
-        $this->assertEquals(0, $t['a']);
+        $table = Table::fromKVs('a', 0);
+        $this->assertEquals(0, $table['a']);
     }
 }

--- a/tests/php/LexerTest.php
+++ b/tests/php/LexerTest.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Phel;
+namespace PhelTest;
 
 use Phel\Lang\SourceLocation;
+use Phel\Lexer;
+use Phel\Token;
 use PHPUnit\Framework\TestCase;
 
 final class LexerTest extends TestCase

--- a/tests/php/PrinterTest.php
+++ b/tests/php/PrinterTest.php
@@ -2,8 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Phel;
+namespace PhelTest;
 
+use Phel\GlobalEnvironment;
+use Phel\Lexer;
+use Phel\Printer;
+use Phel\Reader;
 use PHPUnit\Framework\TestCase;
 
 final class PrinterTest extends TestCase

--- a/tests/php/ReaderTest.php
+++ b/tests/php/ReaderTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Phel\Reader;
+declare(strict_types=1);
+
+namespace PhelTest;
 
 use Phel\Exceptions\ReaderException;
 use Phel\GlobalEnvironment;
@@ -20,9 +22,9 @@ ini_set('xdebug.var_display_max_depth', '10');
 ini_set('xdebug.var_display_max_children', '256');
 ini_set('xdebug.var_display_max_data', '1024');
 
-class ReaderTest extends TestCase
+final class ReaderTest extends TestCase
 {
-    public function testReadNumber()
+    public function testReadNumber(): void
     {
         $this->assertEquals(1, $this->read('1'));
         $this->assertEquals(10, $this->read('10'));
@@ -45,7 +47,7 @@ class ReaderTest extends TestCase
         $this->assertEquals(7E-10, $this->read('7E-10'));
     }
 
-    public function testReadKeyword()
+    public function testReadKeyword(): void
     {
         $this->assertEquals(
             $this->loc(new Keyword('test'), 1, 0, 1, 5),
@@ -53,20 +55,20 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testReadBoolean()
+    public function testReadBoolean(): void
     {
         $this->assertEquals(true, $this->read('true'));
         $this->assertEquals(false, $this->read('false'));
     }
 
-    public function testReadNil()
+    public function testReadNil(): void
     {
         $this->assertNull(
             $this->read('nil')
         );
     }
 
-    public function testReadSymbol()
+    public function testReadSymbol(): void
     {
         $this->assertEquals(
             $this->loc(Symbol::create('test'), 1, 0, 1, 4),
@@ -74,51 +76,65 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testRdlist()
+    public function testReadList(): void
     {
         $this->assertEquals(
             $this->loc(new Tuple([], false), 1, 0, 1, 2),
             $this->read('()')
         );
         $this->assertEquals(
-            $this->loc(new Tuple([$this->loc(new Tuple([], false), 1, 1, 1, 3)], false), 1, 0, 1, 4),
+            $this->loc(new Tuple([
+                $this->loc(new Tuple([], false), 1, 1, 1, 3)
+            ], false), 1, 0, 1, 4),
             $this->read('(())')
         );
 
         $this->assertEquals(
-            $this->loc(new Tuple([$this->loc(Symbol::create('a'), 1, 1, 1, 2)], false), 1, 0, 1, 3),
+            $this->loc(new Tuple([
+                $this->loc(Symbol::create('a'), 1, 1, 1, 2)
+            ], false), 1, 0, 1, 3),
             $this->read('(a)')
         );
 
         $this->assertEquals(
-            $this->loc(new Tuple([$this->loc(Symbol::create('a'), 1, 1, 1, 2), $this->loc(Symbol::create('b'), 1, 3, 1, 4)], false), 1, 0, 1, 5),
+            $this->loc(new Tuple([
+                $this->loc(Symbol::create('a'), 1, 1, 1, 2),
+                $this->loc(Symbol::create('b'), 1, 3, 1, 4)
+            ], false), 1, 0, 1, 5),
             $this->read('(a b)')
         );
     }
 
-    public function testRdlistBracket()
+    public function testRdlistBracket(): void
     {
         $this->assertEquals(
             $this->loc(new Tuple([], true), 1, 0, 1, 2),
             $this->read('[]')
         );
         $this->assertEquals(
-            $this->loc(new Tuple([$this->loc(new Tuple([], true), 1, 1, 1, 3)], true), 1, 0, 1, 4),
+            $this->loc(new Tuple([
+                $this->loc(new Tuple([], true), 1, 1, 1, 3)
+            ], true), 1, 0, 1, 4),
             $this->read('[[]]')
         );
 
         $this->assertEquals(
-            $this->loc(new Tuple([$this->loc(Symbol::create('a'), 1, 1, 1, 2)], true), 1, 0, 1, 3),
+            $this->loc(new Tuple([
+                $this->loc(Symbol::create('a'), 1, 1, 1, 2)
+            ], true), 1, 0, 1, 3),
             $this->read('[a]')
         );
 
         $this->assertEquals(
-            $this->loc(new Tuple([$this->loc(Symbol::create('a'), 1, 1, 1, 2), $this->loc(Symbol::create('b'), 1, 3, 1, 4)], true), 1, 0, 1, 5),
+            $this->loc(new Tuple([
+                $this->loc(Symbol::create('a'), 1, 1, 1, 2),
+                $this->loc(Symbol::create('b'), 1, 3, 1, 4)
+            ], true), 1, 0, 1, 5),
             $this->read('[a b]')
         );
     }
 
-    public function testQuote()
+    public function testQuote(): void
     {
         $this->assertEquals(
             $this->loc(new Tuple([
@@ -129,7 +145,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testUnquote()
+    public function testUnquote(): void
     {
         $this->assertEquals(
             $this->loc(new Tuple([
@@ -140,7 +156,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testUnquoteSplice()
+    public function testUnquoteSplice(): void
     {
         $this->assertEquals(
             $this->loc(new Tuple([
@@ -151,7 +167,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testQuasiquote1()
+    public function testQuasiquote1(): void
     {
         $this->assertEquals(
             $this->loc(new Tuple([
@@ -162,7 +178,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testQuasiquote2()
+    public function testQuasiquote2(): void
     {
         $this->assertEquals(
             $this->loc(new Tuple([
@@ -173,7 +189,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testQuasiquote3()
+    public function testQuasiquote3(): void
     {
         $this->assertEquals(
             $this->read('(apply tuple (concat (tuple (quote foo)) (tuple bar)))', true),
@@ -181,7 +197,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testQuasiquote4()
+    public function testQuasiquote4(): void
     {
         $this->assertEquals(
             $this->read('\'a', true),
@@ -189,7 +205,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testQuasiquote5()
+    public function testQuasiquote5(): void
     {
         $this->assertEquals(
             $this->read('(apply tuple (concat (tuple (quote foo)) bar))', true),
@@ -197,7 +213,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testQuasiquote6()
+    public function testQuasiquote6(): void
     {
         $this->assertEquals(
             $this->read('(apply tuple (concat (tuple foo) bar))', true),
@@ -205,7 +221,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testQuasiquote7()
+    public function testQuasiquote7(): void
     {
         $this->assertEquals(
             $this->read('(apply tuple (concat foo bar))', true),
@@ -213,7 +229,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testQuasiquote8()
+    public function testQuasiquote8(): void
     {
         $this->assertEquals(
             $this->read('(apply tuple (concat foo bar (tuple 1) (tuple "string") (tuple :keyword) (tuple true) (tuple nil)))', true),
@@ -221,7 +237,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testReadString()
+    public function testReadString(): void
     {
         $this->assertEquals(
             'abc',
@@ -254,7 +270,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testReadEmptyArray()
+    public function testReadEmptyArray(): void
     {
         $this->assertEquals(
             $this->loc(PhelArray::create(), 1, 0, 1, 3),
@@ -262,7 +278,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testReadArray1()
+    public function testReadArray1(): void
     {
         $this->assertEquals(
             $this->loc(PhelArray::create(1), 1, 0, 1, 4),
@@ -270,7 +286,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testReadArray2()
+    public function testReadArray2(): void
     {
         $this->assertEquals(
             $this->loc(PhelArray::create(1, 2), 1, 0, 1, 6),
@@ -278,7 +294,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testReadEmptyTable()
+    public function testReadEmptyTable(): void
     {
         $this->assertEquals(
             $this->loc(Table::fromKVs(), 1, 0, 1, 3),
@@ -286,7 +302,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testReadTable1()
+    public function testReadTable1(): void
     {
         $this->assertEquals(
             $this->loc(Table::fromKVs($this->loc(new Keyword('a'), 1, 2, 1, 4), 1), 1, 0, 1, 7),
@@ -294,21 +310,26 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testReadTable2()
+    public function testReadTable2(): void
     {
         $this->assertEquals(
-            $this->loc(Table::fromKVs($this->loc(new Keyword('a'), 1, 2, 1, 4), 1, $this->loc(new Keyword('b'), 1, 7, 1, 9), 2), 1, 0, 1, 12),
+            $this->loc(Table::fromKVs(
+                $this->loc(new Keyword('a'), 1, 2, 1, 4),
+                1,
+                $this->loc(new Keyword('b'), 1, 7, 1, 9),
+                2
+            ), 1, 0, 1, 12),
             $this->read('@{:a 1 :b 2}')
         );
     }
 
-    public function testTableUneven()
+    public function testTableUneven(): void
     {
         $this->expectException(ReaderException::class);
         $this->read('@{:a}');
     }
 
-    public function testMetaKeyword()
+    public function testMetaKeyword(): void
     {
         $this->assertEquals(
             $this->loc(
@@ -328,16 +349,13 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testMetaString()
+    public function testMetaString(): void
     {
         $this->assertEquals(
             $this->loc(
                 $this->withMeta(
                     Symbol::create('test'),
-                    Table::fromKVs(
-                        new Keyword('tag'),
-                        'test'
-                    )
+                    Table::fromKVs(new Keyword('tag'), 'test')
                 ),
                 1,
                 8,
@@ -348,7 +366,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testMetaSymbol()
+    public function testMetaSymbol(): void
     {
         $this->assertEquals(
             $this->loc(
@@ -368,7 +386,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testMetaTable()
+    public function testMetaTable(): void
     {
         $this->assertEquals(
             $this->loc(
@@ -390,7 +408,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testConcatMeta()
+    public function testConcatMeta(): void
     {
         $this->assertEquals(
             $this->loc(
@@ -412,7 +430,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testReadShortFnZeroArgs()
+    public function testReadShortFnZeroArgs(): void
     {
         $this->assertEquals(
             Tuple::create(
@@ -432,7 +450,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testReadShortFnOneArg()
+    public function testReadShortFnOneArg(): void
     {
         $this->assertEquals(
             Tuple::create(
@@ -455,7 +473,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testReadShortFnOneArgTwoTimes()
+    public function testReadShortFnOneArgTwoTimes(): void
     {
         $this->assertEquals(
             Tuple::create(
@@ -479,7 +497,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testReadShortFnTwoArguments()
+    public function testReadShortFnTwoArguments(): void
     {
         $this->assertEquals(
             Tuple::create(
@@ -504,7 +522,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testReadShortFnMissingArgument()
+    public function testReadShortFnMissingArgument(): void
     {
         $this->assertEquals(
             Tuple::create(
@@ -530,7 +548,7 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testReadShortFnRestArguments()
+    public function testReadShortFnRestArguments(): void
     {
         $this->assertEquals(
             Tuple::create(
@@ -556,7 +574,8 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function read($string, $removeLoc = false)
+    /** @return AbstractType|scalar|null */
+    public function read($string, bool $removeLoc = false)
     {
         Symbol::resetGen();
         $globalEnv = new GlobalEnvironment();
@@ -573,19 +592,20 @@ class ReaderTest extends TestCase
         return $result;
     }
 
-    private function withMeta(IMeta $x, Table $t)
+    private function withMeta(IMeta $x, Table $t): IMeta
     {
         $x->setMeta($t);
         return $x;
     }
 
-    private function loc(AbstractType $x, $beginLine, $beginColumn, $endLine, $endColumn)
+    private function loc(AbstractType $x, $beginLine, $beginColumn, $endLine, $endColumn): AbstractType
     {
         $x->setStartLocation(new SourceLocation('string', $beginLine, $beginColumn));
         $x->setEndLocation(new SourceLocation('string', $endLine, $endColumn));
         return $x;
     }
 
+    /** @param AbstractType|scalar|null $x */
     private function removeLoc($x)
     {
         if ($x instanceof AbstractType) {

--- a/tests/php/RuntimeMock.php
+++ b/tests/php/RuntimeMock.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest;
+
+use Phel\GlobalEnvironment;
+use Phel\Runtime;
+
+final class RuntimeMock extends Runtime
+{
+    public array $files = [];
+    public ?string $loadedFile = null;
+
+    public function __construct()
+    {
+        $this->globalEnv = new GlobalEnvironment();
+    }
+
+    public function setFiles(array $files): void
+    {
+        $this->files = $files;
+    }
+
+    protected function loadFile(string $filename, string $ns): bool
+    {
+        $this->loadedFile = $filename;
+
+        return true;
+    }
+
+    protected function fileExists($filename): bool
+    {
+        return in_array($filename, $this->files);
+    }
+}

--- a/tests/php/RuntimeTest.php
+++ b/tests/php/RuntimeTest.php
@@ -1,43 +1,14 @@
 <?php
 
-namespace Phel;
+declare(strict_types=1);
+
+namespace PhelTest;
 
 use PHPUnit\Framework\TestCase;
 
-class RuntimeMock extends Runtime
+final class RuntimeTest extends TestCase
 {
-    public $files = [];
-    public $loadedFile = null;
-
-    public function __construct()
-    {
-        $this->globalEnv = new GlobalEnvironment();
-    }
-
-    public function setFiles(array $files)
-    {
-        $this->files = $files;
-    }
-
-    protected function loadFile(string $filename, string $ns): bool
-    {
-        $this->loadedFile = $filename;
-        return true;
-    }
-
-    protected function fileExists($filename): bool
-    {
-        return in_array($filename, $this->files);
-    }
-}
-
-class RuntimeTest extends TestCase
-{
-
-    /**
-     * @var RuntimeMock
-     */
-    protected $runtime;
+    private RuntimeMock $runtime;
 
     public function setUp(): void
     {
@@ -57,7 +28,7 @@ class RuntimeTest extends TestCase
         $this->runtime->addPath('Foo\\Bar\\Baz\\Dib\\Zim\\Gir\\', ['/vendor/foo.bar.baz.dib.zim.gir/src']);
     }
 
-    public function testExistingFile()
+    public function testExistingFile(): void
     {
         $this->runtime->loadNs('Foo\Bar\Core');
         $this->assertEquals(
@@ -72,12 +43,12 @@ class RuntimeTest extends TestCase
         );
     }
 
-    public function testMissing()
+    public function testMissing(): void
     {
         $this->assertFalse($this->runtime->loadNs('No_Vendor\No_Package\NoClass'));
     }
 
-    public function testDeepFile()
+    public function testDeepFile(): void
     {
         $this->runtime->loadNs('Foo\Bar\Baz\Dib\Zim\Gir\Core');
         $this->assertEquals(
@@ -86,7 +57,7 @@ class RuntimeTest extends TestCase
         );
     }
 
-    public function testConfusion()
+    public function testConfusion(): void
     {
         $this->runtime->loadNs('Foo\Bar\Doom');
         $this->assertEquals(

--- a/tests/php/SourceMap/VLQTest.php
+++ b/tests/php/SourceMap/VLQTest.php
@@ -1,70 +1,73 @@
 <?php
 
-namespace Phel\SourceMap;
+namespace PhelTest\SourceMap;
 
+use Phel\SourceMap\VLQ;
 use PHPUnit\Framework\TestCase;
 
-class VLQTest extends TestCase
+final class VLQTest extends TestCase
 {
-    public function testEncode1()
+    public function testEncode1(): void
     {
-        $this->assertEquals('AAAA', $this->encode([0,0,0,0]));
+        $this->assertEquals('AAAA', $this->encode([0, 0, 0, 0]));
     }
 
-    public function testEncode2()
+    public function testEncode2(): void
     {
         $this->assertEquals('AAgBC', $this->encode([0, 0, 16, 1]));
     }
 
-    public function testEncode3()
+    public function testEncode3(): void
     {
         $this->assertEquals('D', $this->encode([-1]));
     }
 
-    public function testEncode4()
+    public function testEncode4(): void
     {
         $this->assertEquals('B', $this->encode([-2147483648]));
     }
 
-    public function testEncode5()
+    public function testEncode5(): void
     {
         $this->assertEquals('+/////D', $this->encode([2147483647]));
     }
 
-    public function testDecode1()
+    public function testDecode1(): void
     {
-        $this->assertEquals([0,0,0,0], $this->decode('AAAA'));
+        $this->assertEquals([0, 0, 0, 0], $this->decode('AAAA'));
     }
 
-    public function testDecode2()
+    public function testDecode2(): void
     {
         $this->assertEquals([0, 0, 16, 1], $this->decode('AAgBC'));
     }
 
-    public function testDecode3()
+    public function testDecode3(): void
     {
         $this->assertEquals([-1], $this->decode('D'));
     }
 
-    public function testDecode4()
+    public function testDecode4(): void
     {
         $this->assertEquals([-2147483648], $this->decode('B'));
     }
 
-    public function testDecode5()
+    public function testDecode5(): void
     {
         $this->assertEquals([2147483647], $this->decode('+/////D'));
     }
 
-    public function encode(array $xs)
+    private function encode(array $xs): string
     {
         $service = new VLQ();
+
         return $service->encodeIntegers($xs);
     }
 
-    public function decode(string $s)
+    private function decode(string $s): array
     {
         $service = new VLQ();
+
         return $service->decode($s);
     }
 }


### PR DESCRIPTION
# Description

I defined `PhelTest` namespace and some other minor improvements to all unit test files.

# Changes

- Moved all `test/php` tests from `Phel` to `PhelTest` namespace.
- Declared all tests as [final](https://medium.com/@chemaclass/final-classes-in-php-9174e3e2747e) and [strict](https://github.com/Chemaclass/php-best-practices/blob/master/technical-skills/strict-types.md) as well.
- Moved the "inner class" `RuntimeMock` to its own file.