### PR TITLE
Sets correct namespace for loader-dev and tests.

### DIFF
--- a/doc/content/documentation/configuration.md
+++ b/doc/content/documentation/configuration.md
@@ -16,7 +16,7 @@ These are all Phel specific configuration options available.
             "hello-world\\": "src/"
         },
         "loader-dev": {
-            "hello-world\\": "tests/"
+            "hello-world\\tests\\": "tests/"
         },
         "tests": [
             "tests/"

--- a/doc/content/documentation/testing.md
+++ b/doc/content/documentation/testing.md
@@ -64,7 +64,7 @@ This tests whether the execution of `body` prints the `expected` text to the out
 Test can be defined by using the `deftest` macro. This macro is like a function without arguments.
 
 ```phel
-(ns my-namespace
+(ns my-namespace\tests
   (:require phel\test :refer [deftest is]))
 
 (deftest my-test


### PR DESCRIPTION
# Description

Documentation changes to avoid beginner mistakes.

See issue #90.

# Changes

- Changes `hello-world\\` in `composer.json` under key `loader-dev` to `hello-world\\tests\\` (Configuration).
- Appends `tests` to namespace in testing documentation.