### PR TITLE
Refactoring RecurSymbol and NodeEnvironment

### DIFF
--- a/src/php/Ast/RecurNode.php
+++ b/src/php/Ast/RecurNode.php
@@ -13,20 +13,20 @@ final class RecurNode extends Node
     private RecurFrame $frame;
 
     /** @var Node[] */
-    private array $exprs;
+    private array $expressions;
 
     /**
-     * @param Node[] $exprs
+     * @param Node[] $expressions
      */
     public function __construct(
         NodeEnvironment $env,
         RecurFrame $frame,
-        array $exprs,
+        array $expressions,
         ?SourceLocation $sourceLocation = null
     ) {
         parent::__construct($env, $sourceLocation);
         $this->frame = $frame;
-        $this->exprs = $exprs;
+        $this->expressions = $expressions;
     }
 
     public function getFrame(): RecurFrame
@@ -37,8 +37,8 @@ final class RecurNode extends Node
     /**
      * @return Node[]
      */
-    public function getExprs(): array
+    public function getExpressions(): array
     {
-        return $this->exprs;
+        return $this->expressions;
     }
 }

--- a/src/php/Emitter.php
+++ b/src/php/Emitter.php
@@ -410,7 +410,7 @@ final class Emitter
     private function emitRecur(RecurNode $node): void
     {
         $params = $node->getFrame()->getParams();
-        $exprs = $node->getExprs();
+        $exprs = $node->getExpressions();
         $env = $node->getEnv();
 
         $tempSyms = [];

--- a/src/php/NodeEnvironment.php
+++ b/src/php/NodeEnvironment.php
@@ -31,7 +31,7 @@ final class NodeEnvironment
 
     /**
      * A list of RecurFrame
-     * @var RecurFrame[]
+     * @var array<RecurFrame|null>
      */
     private array $recurFrames;
 
@@ -44,7 +44,7 @@ final class NodeEnvironment
      * @param Symbol[] $locals A list of local symbols
      * @param string $context The current context (Expression, Statement or Return)
      * @param Symbol[] $shadowed A list of shadowed variables
-     * @param RecurFrame[] $recurFrames A list of RecurFrame
+     * @param array<RecurFrame|null> $recurFrames A list of RecurFrame
      * @param string|null $boundTo A variable this is bound to
      */
     public function __construct(
@@ -153,7 +153,7 @@ final class NodeEnvironment
     public function withDisallowRecurFrame(): NodeEnvironment
     {
         $result = clone $this;
-        $result->recurFrames = array_merge($this->recurFrames, [RecurFrame::withoutParams()]);
+        $result->recurFrames = array_merge($this->recurFrames, [null]);
 
         return $result;
     }

--- a/src/php/RecurFrame.php
+++ b/src/php/RecurFrame.php
@@ -1,21 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel;
 
 use Phel\Lang\Symbol;
 
-class RecurFrame
+final class RecurFrame
 {
+    private bool $isActive = false;
 
-    /**
-     * @var bool
-     */
-    private $isActive = false;
+    /** @var Symbol[] */
+    private array $params;
 
-    /**
-     * @var Symbol[]
-     */
-    private $params;
+    public static function withoutParams(): self
+    {
+        return new self([]);
+    }
 
     public function __construct(array $params)
     {

--- a/src/php/RecurFrame.php
+++ b/src/php/RecurFrame.php
@@ -13,11 +13,6 @@ final class RecurFrame
     /** @var Symbol[] */
     private array $params;
 
-    public static function withoutParams(): self
-    {
-        return new self([]);
-    }
-
     public function __construct(array $params)
     {
         $this->params = $params;


### PR DESCRIPTION
# Description

I just clean up a little bit the `RecurSymbol` and `NodeEnvironment` classes

# Changes

- Refactor a little bit the `RecurSymbol` and `NodeEnvironment` classes
- Renamed `exprs` to `expressions`
- No functionality was altered
