### PR TITLE
Add tests to PhpObjectCallSymbol class

### DIFF
--- a/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
@@ -56,14 +56,6 @@ final class PhpObjectCallSymbol
 
     private function callExprForMethodCall(NodeEnvironment $env, Tuple $tuple): MethodCallNode
     {
-        if (count($tuple) < 1) {
-            throw AnalyzerException::withLocation('Function name is missing', $tuple);
-        }
-
-        if (!$tuple[2] instanceof Tuple) {
-            throw AnalyzerException::withLocation('Second argument of must be a Tuple', $tuple);
-        }
-
         /** @var Tuple $tuple2 */
         $tuple2 = $tuple[2];
         $tCount = count($tuple2);
@@ -81,10 +73,6 @@ final class PhpObjectCallSymbol
 
     private function callExprForPropertyCall(NodeEnvironment $env, Tuple $tuple): PropertyOrConstantAccessNode
     {
-        if (!$tuple[2] instanceof Symbol) {
-            throw AnalyzerException::withLocation('Second argument of must be a Symbol', $tuple);
-        }
-
         return new PropertyOrConstantAccessNode($env, $tuple[2], $tuple[2]->getStartLocation());
     }
 }

--- a/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
@@ -73,6 +73,10 @@ final class PhpObjectCallSymbol
 
     private function callExprForPropertyCall(NodeEnvironment $env, Tuple $tuple): PropertyOrConstantAccessNode
     {
-        return new PropertyOrConstantAccessNode($env, $tuple[2], $tuple[2]->getStartLocation());
+        /** @var Symbol $tuple2 */
+        $tuple2 = $tuple[2];
+
+        /** @psalm-suppress PossiblyNullArgument */
+        return new PropertyOrConstantAccessNode($env, $tuple2, $tuple2->getStartLocation());
     }
 }

--- a/tests/php/Analyzer/TupleSymbol/PhpObjectCallSymbolTest.php
+++ b/tests/php/Analyzer/TupleSymbol/PhpObjectCallSymbolTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhelTest\Analyzer\TupleSymbol;
+
+use Phel\Analyzer;
+use Phel\Analyzer\TupleSymbol\PhpObjectCallSymbol;
+use Phel\Ast\MethodCallNode;
+use Phel\Ast\PhpClassNameNode;
+use Phel\Ast\PropertyOrConstantAccessNode;
+use Phel\Exceptions\PhelCodeException;
+use Phel\GlobalEnvironment;
+use Phel\Lang\Symbol;
+use Phel\Lang\Tuple;
+use Phel\NodeEnvironment;
+use PHPUnit\Framework\TestCase;
+
+final class PhpObjectCallSymbolTest extends TestCase
+{
+    private Analyzer $analyzer;
+
+    public function setUp(): void
+    {
+        $this->analyzer = new Analyzer(new GlobalEnvironment());
+    }
+
+    public function testTupleWithoutArgument(): void
+    {
+        $this->expectException(PhelCodeException::class);
+        $this->expectExceptionMessage("Exactly two arguments are expected for 'php/::");
+
+        $tuple = Tuple::create(
+            Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL),
+            Symbol::create('\\')
+        );
+        (new PhpObjectCallSymbol($this->analyzer))($tuple, NodeEnvironment::empty(), $isStatic = true);
+    }
+
+    public function testTupleWithWrongSymbol(): void
+    {
+        $this->expectException(PhelCodeException::class);
+        $this->expectExceptionMessage("Second argument of 'php/-> must be a Tuple or a Symbol");
+
+        $tuple = Tuple::create(
+            Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
+            Symbol::create('\\'),
+            ''
+        );
+        (new PhpObjectCallSymbol($this->analyzer))($tuple, NodeEnvironment::empty(), $isStatic = false);
+    }
+
+    public function testIsStatic(): void
+    {
+        $tuple = Tuple::create(
+            Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
+            Symbol::create('\\'),
+            Symbol::create('')
+        );
+        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))($tuple, NodeEnvironment::empty(), $isStatic = true);
+        self::assertSame($isStatic, $objCallNode->isStatic());
+        self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
+        self::assertInstanceOf(PropertyOrConstantAccessNode::class, $objCallNode->getCallExpr());
+    }
+
+    public function testIsNotStatic(): void
+    {
+        $tuple = Tuple::create(
+            Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
+            Symbol::create('\\'),
+            Symbol::create('')
+        );
+        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))($tuple, NodeEnvironment::empty(), $isStatic = false);
+        self::assertSame($isStatic, $objCallNode->isStatic());
+        self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
+        self::assertInstanceOf(PropertyOrConstantAccessNode::class, $objCallNode->getCallExpr());
+    }
+
+    public function testTuple2ndElemIsTuple(): void
+    {
+        $tuple = Tuple::create(
+            Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL),
+            Symbol::create('\\'),
+            Tuple::create(Symbol::create(''), '', '')
+        );
+        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))($tuple, NodeEnvironment::empty(), $isStatic = true);
+        self::assertTrue($objCallNode->isMethodCall());
+        self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
+        self::assertInstanceOf(MethodCallNode::class, $objCallNode->getCallExpr());
+    }
+
+    public function testTuple2ndElemIsSymbol(): void
+    {
+        $tuple = Tuple::create(
+            Symbol::create(Symbol::NAME_PHP_OBJECT_CALL),
+            Symbol::create('\\'),
+            Symbol::create('')
+        );
+        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))($tuple, NodeEnvironment::empty(), $isStatic = true);
+        self::assertFalse($objCallNode->isMethodCall());
+        self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
+        self::assertInstanceOf(PropertyOrConstantAccessNode::class, $objCallNode->getCallExpr());
+    }
+}


### PR DESCRIPTION
# Description

1. We checked on line 26: `if (count($tuple) !== 3)`, so, it is not possible to reach the condition on line 59.
2. We checked on line 30: if `$tuple[2]` instance of `Tuple` or `Symbol`, and on line 39 we check if `$tuple[2]` is `Tuple`, so, the else branch is possible only when the object is a `Tuple` object (and vice versa), for that reason, conditions on lines 63 & 84 are also not necessary.

At this point I have some questions, would be possible this class could be extended making those guard clauses necessaries in the future?
I mean, what do you think is better, that "repeating" code but not having 100% but probably more secure or and have the 100%  covered without those clauses as I did in the PR? @jenshaase  

# Changes

- Remove some impossible guard clauses from `PhpObjectCallSymbol` class
- Create `PhpObjectCallSymbolTest` class