### PR TITLE
Replace __invoke() to analyze()

### DIFF
--- a/src/php/Analyzer.php
+++ b/src/php/Analyzer.php
@@ -43,27 +43,27 @@ final class Analyzer
     public function analyze($x, NodeEnvironment $env): Node
     {
         if ($this->isLiteral($x)) {
-            return (new AnalyzeLiteral())($x, $env);
+            return (new AnalyzeLiteral())->toNode($x, $env);
         }
 
         if ($x instanceof Symbol) {
-            return (new AnalyzeSymbol($this))($x, $env);
+            return (new AnalyzeSymbol($this))->toNode($x, $env);
         }
 
         if ($x instanceof Tuple && $x->isUsingBracket()) {
-            return (new AnalyzeBracketTuple($this))($x, $env);
+            return (new AnalyzeBracketTuple($this))->toNode($x, $env);
         }
 
         if ($x instanceof PhelArray) {
-            return (new AnalyzeArray($this))($x, $env);
+            return (new AnalyzeArray($this))->toNode($x, $env);
         }
 
         if ($x instanceof Table) {
-            return (new AnalyzeTable($this))($x, $env);
+            return (new AnalyzeTable($this))->toNode($x, $env);
         }
 
         if ($x instanceof Tuple) {
-            return (new AnalyzeTuple($this))($x, $env);
+            return (new AnalyzeTuple($this))->toNode($x, $env);
         }
 
         throw new AnalyzerException('Unhandled type: ' . var_export($x, true));

--- a/src/php/Analyzer.php
+++ b/src/php/Analyzer.php
@@ -43,27 +43,27 @@ final class Analyzer
     public function analyze($x, NodeEnvironment $env): Node
     {
         if ($this->isLiteral($x)) {
-            return (new AnalyzeLiteral())->toNode($x, $env);
+            return (new AnalyzeLiteral())->analyze($x, $env);
         }
 
         if ($x instanceof Symbol) {
-            return (new AnalyzeSymbol($this))->toNode($x, $env);
+            return (new AnalyzeSymbol($this))->analyze($x, $env);
         }
 
         if ($x instanceof Tuple && $x->isUsingBracket()) {
-            return (new AnalyzeBracketTuple($this))->toNode($x, $env);
+            return (new AnalyzeBracketTuple($this))->analyze($x, $env);
         }
 
         if ($x instanceof PhelArray) {
-            return (new AnalyzeArray($this))->toNode($x, $env);
+            return (new AnalyzeArray($this))->analyze($x, $env);
         }
 
         if ($x instanceof Table) {
-            return (new AnalyzeTable($this))->toNode($x, $env);
+            return (new AnalyzeTable($this))->analyze($x, $env);
         }
 
         if ($x instanceof Tuple) {
-            return (new AnalyzeTuple($this))->toNode($x, $env);
+            return (new AnalyzeTuple($this))->analyze($x, $env);
         }
 
         throw new AnalyzerException('Unhandled type: ' . var_export($x, true));

--- a/src/php/Analyzer/AnalyzeArray.php
+++ b/src/php/Analyzer/AnalyzeArray.php
@@ -12,7 +12,7 @@ final class AnalyzeArray
 {
     use WithAnalyzer;
 
-    public function toNode(PhelArray $array, NodeEnvironment $env): ArrayNode
+    public function analyze(PhelArray $array, NodeEnvironment $env): ArrayNode
     {
         $values = [];
         $valueEnv = $env->withContext(NodeEnvironment::CTX_EXPR);

--- a/src/php/Analyzer/AnalyzeArray.php
+++ b/src/php/Analyzer/AnalyzeArray.php
@@ -12,7 +12,7 @@ final class AnalyzeArray
 {
     use WithAnalyzer;
 
-    public function __invoke(PhelArray $array, NodeEnvironment $env): ArrayNode
+    public function toNode(PhelArray $array, NodeEnvironment $env): ArrayNode
     {
         $values = [];
         $valueEnv = $env->withContext(NodeEnvironment::CTX_EXPR);

--- a/src/php/Analyzer/AnalyzeBracketTuple.php
+++ b/src/php/Analyzer/AnalyzeBracketTuple.php
@@ -12,7 +12,7 @@ final class AnalyzeBracketTuple
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): TupleNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): TupleNode
     {
         $args = [];
 

--- a/src/php/Analyzer/AnalyzeBracketTuple.php
+++ b/src/php/Analyzer/AnalyzeBracketTuple.php
@@ -12,7 +12,7 @@ final class AnalyzeBracketTuple
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): TupleNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): TupleNode
     {
         $args = [];
 

--- a/src/php/Analyzer/AnalyzeLiteral.php
+++ b/src/php/Analyzer/AnalyzeLiteral.php
@@ -11,7 +11,7 @@ use Phel\NodeEnvironment;
 final class AnalyzeLiteral
 {
     /** @param AbstractType|scalar|null $value */
-    public function toNode($value, NodeEnvironment $env): LiteralNode
+    public function analyze($value, NodeEnvironment $env): LiteralNode
     {
         $sourceLocation = ($value instanceof AbstractType)
             ? $value->getStartLocation()

--- a/src/php/Analyzer/AnalyzeLiteral.php
+++ b/src/php/Analyzer/AnalyzeLiteral.php
@@ -11,9 +11,11 @@ use Phel\NodeEnvironment;
 final class AnalyzeLiteral
 {
     /** @param AbstractType|scalar|null $value */
-    public function __invoke($value, NodeEnvironment $env): LiteralNode
+    public function toNode($value, NodeEnvironment $env): LiteralNode
     {
-        $sourceLocation = ($value instanceof AbstractType) ? $value->getStartLocation() : null;
+        $sourceLocation = ($value instanceof AbstractType)
+            ? $value->getStartLocation()
+            : null;
 
         return new LiteralNode($env, $value, $sourceLocation);
     }

--- a/src/php/Analyzer/AnalyzeSymbol.php
+++ b/src/php/Analyzer/AnalyzeSymbol.php
@@ -15,7 +15,7 @@ final class AnalyzeSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Symbol $symbol, NodeEnvironment $env): Node
+    public function toNode(Symbol $symbol, NodeEnvironment $env): Node
     {
         if ($symbol->getNamespace() === 'php') {
             return new PhpVarNode($env, $symbol->getName(), $symbol->getStartLocation());

--- a/src/php/Analyzer/AnalyzeSymbol.php
+++ b/src/php/Analyzer/AnalyzeSymbol.php
@@ -15,7 +15,7 @@ final class AnalyzeSymbol
 {
     use WithAnalyzer;
 
-    public function toNode(Symbol $symbol, NodeEnvironment $env): Node
+    public function analyze(Symbol $symbol, NodeEnvironment $env): Node
     {
         if ($symbol->getNamespace() === 'php') {
             return new PhpVarNode($env, $symbol->getName(), $symbol->getStartLocation());

--- a/src/php/Analyzer/AnalyzeTable.php
+++ b/src/php/Analyzer/AnalyzeTable.php
@@ -12,7 +12,7 @@ final class AnalyzeTable
 {
     use WithAnalyzer;
 
-    public function toNode(Table $table, NodeEnvironment $env): TableNode
+    public function analyze(Table $table, NodeEnvironment $env): TableNode
     {
         $keyValues = [];
         $kvEnv = $env->withContext(NodeEnvironment::CTX_EXPR);

--- a/src/php/Analyzer/AnalyzeTable.php
+++ b/src/php/Analyzer/AnalyzeTable.php
@@ -12,7 +12,7 @@ final class AnalyzeTable
 {
     use WithAnalyzer;
 
-    public function __invoke(Table $table, NodeEnvironment $env): TableNode
+    public function toNode(Table $table, NodeEnvironment $env): TableNode
     {
         $keyValues = [];
         $kvEnv = $env->withContext(NodeEnvironment::CTX_EXPR);

--- a/src/php/Analyzer/AnalyzeTuple.php
+++ b/src/php/Analyzer/AnalyzeTuple.php
@@ -37,7 +37,7 @@ final class AnalyzeTuple
     use WithAnalyzer;
 
     /** @throws AnalyzerException|PhelCodeException */
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): Node
+    public function toNode(Tuple $tuple, NodeEnvironment $env): Node
     {
         if (!$tuple[0] instanceof Symbol) {
             return (new InvokeSymbol($this->analyzer))($tuple, $env);

--- a/src/php/Analyzer/AnalyzeTuple.php
+++ b/src/php/Analyzer/AnalyzeTuple.php
@@ -40,54 +40,54 @@ final class AnalyzeTuple
     public function toNode(Tuple $tuple, NodeEnvironment $env): Node
     {
         if (!$tuple[0] instanceof Symbol) {
-            return (new InvokeSymbol($this->analyzer))($tuple, $env);
+            return (new InvokeSymbol($this->analyzer))->toNode($tuple, $env);
         }
 
         switch ($tuple[0]->getFullName()) {
             case Symbol::NAME_DEF:
-                return (new DefSymbol($this->analyzer))($tuple, $env);
+                return (new DefSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_NS:
-                return (new NsSymbol($this->analyzer))($tuple, $env);
+                return (new NsSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_FN:
-                return (new FnSymbol($this->analyzer))($tuple, $env);
+                return (new FnSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_QUOTE:
-                return (new QuoteSymbol())($tuple, $env);
+                return (new QuoteSymbol())->toNode($tuple, $env);
             case Symbol::NAME_DO:
-                return (new DoSymbol($this->analyzer))($tuple, $env);
+                return (new DoSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_IF:
-                return (new IfSymbol($this->analyzer))($tuple, $env);
+                return (new IfSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_APPLY:
-                return (new ApplySymbol($this->analyzer))($tuple, $env);
+                return (new ApplySymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_LET:
-                return (new LetSymbol($this->analyzer))($tuple, $env);
+                return (new LetSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_PHP_NEW:
-                return (new PhpNewSymbol($this->analyzer))($tuple, $env);
+                return (new PhpNewSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_PHP_OBJECT_CALL:
-                return (new PhpObjectCallSymbol($this->analyzer))($tuple, $env, false);
+                return (new PhpObjectCallSymbol($this->analyzer))->toNode($tuple, $env, $static = false);
             case Symbol::NAME_PHP_OBJECT_STATIC_CALL:
-                return (new PhpObjectCallSymbol($this->analyzer))($tuple, $env, true);
+                return (new PhpObjectCallSymbol($this->analyzer))->toNode($tuple, $env, $static = true);
             case Symbol::NAME_PHP_ARRAY_GET:
-                return (new PhpAGetSymbol($this->analyzer))($tuple, $env);
+                return (new PhpAGetSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_PHP_ARRAY_SET:
-                return (new PhpASetSymbol($this->analyzer))($tuple, $env);
+                return (new PhpASetSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_PHP_ARRAY_PUSH:
-                return (new PhpAPushSymbol($this->analyzer))($tuple, $env);
+                return (new PhpAPushSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_PHP_ARRAY_UNSET:
-                return (new PhpAUnsetSymbol($this->analyzer))($tuple, $env);
+                return (new PhpAUnsetSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_RECUR:
-                return (new RecurSymbol($this->analyzer))($tuple, $env);
+                return (new RecurSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_TRY:
-                return (new TrySymbol($this->analyzer))($tuple, $env);
+                return (new TrySymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_THROW:
-                return (new ThrowSymbol($this->analyzer))($tuple, $env);
+                return (new ThrowSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_LOOP:
-                return (new LoopSymbol($this->analyzer))($tuple, $env);
+                return (new LoopSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_FOREACH:
-                return (new ForeachSymbol($this->analyzer))($tuple, $env);
+                return (new ForeachSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_DEF_STRUCT:
-                return (new DefStructSymbol($this->analyzer))($tuple, $env);
+                return (new DefStructSymbol($this->analyzer))->toNode($tuple, $env);
             default:
-                return (new InvokeSymbol($this->analyzer))($tuple, $env);
+                return (new InvokeSymbol($this->analyzer))->toNode($tuple, $env);
         }
     }
 }

--- a/src/php/Analyzer/AnalyzeTuple.php
+++ b/src/php/Analyzer/AnalyzeTuple.php
@@ -25,7 +25,7 @@ use Phel\Analyzer\TupleSymbol\QuoteSymbol;
 use Phel\Analyzer\TupleSymbol\RecurSymbol;
 use Phel\Analyzer\TupleSymbol\ThrowSymbol;
 use Phel\Analyzer\TupleSymbol\TrySymbol;
-use Phel\Analyzer\TupleSymbol\TupleSymbolToNode;
+use Phel\Analyzer\TupleSymbol\TupleSymbolAnalyzer;
 use Phel\Ast\Node;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Exceptions\PhelCodeException;
@@ -40,12 +40,12 @@ final class AnalyzeTuple
     private const EMPTY_SYMBOL_NAME = '';
 
     /** @throws AnalyzerException|PhelCodeException */
-    public function toNode(Tuple $tuple, NodeEnvironment $env): Node
+    public function analyze(Tuple $tuple, NodeEnvironment $env): Node
     {
         $symbolName = $this->getSymbolName($tuple);
-        $symbol = $this->createSymbolByName($symbolName);
+        $symbol = $this->createSymbolAnalyzerByName($symbolName);
 
-        return $symbol->toNode($tuple, $env);
+        return $symbol->analyze($tuple, $env);
     }
 
     private function getSymbolName(Tuple $tuple): string
@@ -55,7 +55,7 @@ final class AnalyzeTuple
             : self::EMPTY_SYMBOL_NAME;
     }
 
-    private function createSymbolByName(string $symbolName): TupleSymbolToNode
+    private function createSymbolAnalyzerByName(string $symbolName): TupleSymbolAnalyzer
     {
         switch ($symbolName) {
             case Symbol::NAME_DEF:

--- a/src/php/Analyzer/AnalyzeTuple.php
+++ b/src/php/Analyzer/AnalyzeTuple.php
@@ -26,6 +26,7 @@ use Phel\Analyzer\TupleSymbol\QuoteSymbol;
 use Phel\Analyzer\TupleSymbol\RecurSymbol;
 use Phel\Analyzer\TupleSymbol\ThrowSymbol;
 use Phel\Analyzer\TupleSymbol\TrySymbol;
+use Phel\Analyzer\TupleSymbol\TupleSymbolToNode;
 use Phel\Ast\Node;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Exceptions\PhelCodeException;
@@ -37,58 +38,71 @@ final class AnalyzeTuple
 {
     use WithAnalyzer;
 
+    private const EMPTY_SYMBOL_NAME = '';
+
     /** @throws AnalyzerException|PhelCodeException */
     public function toNode(Tuple $tuple, NodeEnvironment $env): Node
     {
-        if (!$tuple[0] instanceof Symbol) {
-            return (new InvokeSymbol($this->analyzer))->toNode($tuple, $env);
-        }
+        $symbolName = $this->getSymbolName($tuple);
+        $symbol = $this->createSymbolByName($symbolName);
 
-        switch ($tuple[0]->getFullName()) {
+        return $symbol->toNode($tuple, $env);
+    }
+
+    private function getSymbolName(Tuple $tuple): string
+    {
+        return isset($tuple[0]) && $tuple[0] instanceof Symbol
+            ? $tuple[0]->getFullName()
+            : self::EMPTY_SYMBOL_NAME;
+    }
+
+    private function createSymbolByName(string $symbolName): TupleSymbolToNode
+    {
+        switch ($symbolName) {
             case Symbol::NAME_DEF:
-                return (new DefSymbol($this->analyzer))->toNode($tuple, $env);
+                return new DefSymbol($this->analyzer);
             case Symbol::NAME_NS:
-                return (new NsSymbol($this->analyzer))->toNode($tuple, $env);
+                return new NsSymbol($this->analyzer);
             case Symbol::NAME_FN:
-                return (new FnSymbol($this->analyzer))->toNode($tuple, $env);
+                return new FnSymbol($this->analyzer);
             case Symbol::NAME_QUOTE:
-                return (new QuoteSymbol())->toNode($tuple, $env);
+                return new QuoteSymbol();
             case Symbol::NAME_DO:
-                return (new DoSymbol($this->analyzer))->toNode($tuple, $env);
+                return new DoSymbol($this->analyzer);
             case Symbol::NAME_IF:
-                return (new IfSymbol($this->analyzer))->toNode($tuple, $env);
+                return new IfSymbol($this->analyzer);
             case Symbol::NAME_APPLY:
-                return (new ApplySymbol($this->analyzer))->toNode($tuple, $env);
+                return new ApplySymbol($this->analyzer);
             case Symbol::NAME_LET:
-                return (new LetSymbol($this->analyzer))->toNode($tuple, $env);
+                return new LetSymbol($this->analyzer);
             case Symbol::NAME_PHP_NEW:
-                return (new PhpNewSymbol($this->analyzer))->toNode($tuple, $env);
+                return new PhpNewSymbol($this->analyzer);
             case Symbol::NAME_PHP_OBJECT_CALL:
-                return (new PhpObjectCallSymbol($this->analyzer, $isStatic = false))->toNode($tuple, $env);
+                return new PhpObjectCallSymbol($this->analyzer, $isStatic = false);
             case Symbol::NAME_PHP_OBJECT_STATIC_CALL:
-                return (new PhpObjectCallSymbol($this->analyzer, $isStatic = true))->toNode($tuple, $env);
+                return new PhpObjectCallSymbol($this->analyzer, $isStatic = true);
             case Symbol::NAME_PHP_ARRAY_GET:
-                return (new PhpAGetSymbol($this->analyzer))->toNode($tuple, $env);
+                return new PhpAGetSymbol($this->analyzer);
             case Symbol::NAME_PHP_ARRAY_SET:
-                return (new PhpASetSymbol($this->analyzer))->toNode($tuple, $env);
+                return new PhpASetSymbol($this->analyzer);
             case Symbol::NAME_PHP_ARRAY_PUSH:
-                return (new PhpAPushSymbol($this->analyzer))->toNode($tuple, $env);
+                return new PhpAPushSymbol($this->analyzer);
             case Symbol::NAME_PHP_ARRAY_UNSET:
-                return (new PhpAUnsetSymbol($this->analyzer))->toNode($tuple, $env);
+                return new PhpAUnsetSymbol($this->analyzer);
             case Symbol::NAME_RECUR:
-                return (new RecurSymbol($this->analyzer))->toNode($tuple, $env);
+                return new RecurSymbol($this->analyzer);
             case Symbol::NAME_TRY:
-                return (new TrySymbol($this->analyzer))->toNode($tuple, $env);
+                return new TrySymbol($this->analyzer);
             case Symbol::NAME_THROW:
-                return (new ThrowSymbol($this->analyzer))->toNode($tuple, $env);
+                return new ThrowSymbol($this->analyzer);
             case Symbol::NAME_LOOP:
-                return (new LoopSymbol($this->analyzer))->toNode($tuple, $env);
+                return new LoopSymbol($this->analyzer);
             case Symbol::NAME_FOREACH:
-                return (new ForeachSymbol($this->analyzer))->toNode($tuple, $env);
+                return new ForeachSymbol($this->analyzer);
             case Symbol::NAME_DEF_STRUCT:
-                return (new DefStructSymbol($this->analyzer))->toNode($tuple, $env);
+                return new DefStructSymbol($this->analyzer);
             default:
-                return (new InvokeSymbol($this->analyzer))->toNode($tuple, $env);
+                return new InvokeSymbol($this->analyzer);
         }
     }
 }

--- a/src/php/Analyzer/AnalyzeTuple.php
+++ b/src/php/Analyzer/AnalyzeTuple.php
@@ -21,6 +21,7 @@ use Phel\Analyzer\TupleSymbol\PhpASetSymbol;
 use Phel\Analyzer\TupleSymbol\PhpAUnsetSymbol;
 use Phel\Analyzer\TupleSymbol\PhpNewSymbol;
 use Phel\Analyzer\TupleSymbol\PhpObjectCallSymbol;
+use Phel\Analyzer\TupleSymbol\PhpObjectStaticCallSymbol;
 use Phel\Analyzer\TupleSymbol\QuoteSymbol;
 use Phel\Analyzer\TupleSymbol\RecurSymbol;
 use Phel\Analyzer\TupleSymbol\ThrowSymbol;
@@ -63,9 +64,9 @@ final class AnalyzeTuple
             case Symbol::NAME_PHP_NEW:
                 return (new PhpNewSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_PHP_OBJECT_CALL:
-                return (new PhpObjectCallSymbol($this->analyzer))->toNode($tuple, $env, $static = false);
+                return (new PhpObjectCallSymbol($this->analyzer, $isStatic = false))->toNode($tuple, $env);
             case Symbol::NAME_PHP_OBJECT_STATIC_CALL:
-                return (new PhpObjectCallSymbol($this->analyzer))->toNode($tuple, $env, $static = true);
+                return (new PhpObjectCallSymbol($this->analyzer, $isStatic = true))->toNode($tuple, $env);
             case Symbol::NAME_PHP_ARRAY_GET:
                 return (new PhpAGetSymbol($this->analyzer))->toNode($tuple, $env);
             case Symbol::NAME_PHP_ARRAY_SET:

--- a/src/php/Analyzer/TupleSymbol/ApplySymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ApplySymbol.php
@@ -12,7 +12,7 @@ use Phel\Lang\AbstractType;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class ApplySymbol implements TupleToNode
+final class ApplySymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/ApplySymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ApplySymbol.php
@@ -12,7 +12,7 @@ use Phel\Lang\AbstractType;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class ApplySymbol
+final class ApplySymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/ApplySymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ApplySymbol.php
@@ -12,11 +12,11 @@ use Phel\Lang\AbstractType;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class ApplySymbol implements TupleSymbolToNode
+final class ApplySymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): ApplyNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): ApplyNode
     {
         if (count($tuple) < 3) {
             throw AnalyzerException::withLocation("At least three arguments are required for 'apply", $tuple);

--- a/src/php/Analyzer/TupleSymbol/ApplySymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ApplySymbol.php
@@ -16,7 +16,7 @@ final class ApplySymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): ApplyNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): ApplyNode
     {
         if (count($tuple) < 3) {
             throw AnalyzerException::withLocation("At least three arguments are required for 'apply", $tuple);

--- a/src/php/Analyzer/TupleSymbol/DefStructSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DefStructSymbol.php
@@ -15,7 +15,7 @@ final class DefStructSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): DefStructNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): DefStructNode
     {
         if (count($tuple) !== 3) {
             throw AnalyzerException::withLocation(

--- a/src/php/Analyzer/TupleSymbol/DefStructSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DefStructSymbol.php
@@ -11,7 +11,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class DefStructSymbol implements TupleToNode
+final class DefStructSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/DefStructSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DefStructSymbol.php
@@ -11,7 +11,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class DefStructSymbol
+final class DefStructSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/DefStructSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DefStructSymbol.php
@@ -11,11 +11,11 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class DefStructSymbol implements TupleSymbolToNode
+final class DefStructSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): DefStructNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): DefStructNode
     {
         if (count($tuple) !== 3) {
             throw AnalyzerException::withLocation(

--- a/src/php/Analyzer/TupleSymbol/DefSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DefSymbol.php
@@ -18,7 +18,7 @@ final class DefSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): DefNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): DefNode
     {
         $countX = count($tuple);
         if ($countX < 3 || $countX > 4) {

--- a/src/php/Analyzer/TupleSymbol/DefSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DefSymbol.php
@@ -14,7 +14,7 @@ use Phel\Lang\Table;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class DefSymbol
+final class DefSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/DefSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DefSymbol.php
@@ -14,7 +14,7 @@ use Phel\Lang\Table;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class DefSymbol implements TupleToNode
+final class DefSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/DefSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DefSymbol.php
@@ -16,7 +16,7 @@ use Phel\Lang\Table;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class DefSymbol implements TupleSymbolToNode
+final class DefSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
@@ -25,7 +25,7 @@ final class DefSymbol implements TupleSymbolToNode
     /**
      * @throws PhelCodeException
      */
-    public function toNode(Tuple $tuple, NodeEnvironment $env): DefNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): DefNode
     {
         $this->ensureDefIsAllowed($tuple, $env);
         $this->verifySizeOfTuple($tuple);

--- a/src/php/Analyzer/TupleSymbol/DoSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DoSymbol.php
@@ -10,11 +10,11 @@ use Phel\Ast\Node;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class DoSymbol implements TupleSymbolToNode
+final class DoSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): DoNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): DoNode
     {
         $tupleCount = count($tuple);
         $stmts = [];

--- a/src/php/Analyzer/TupleSymbol/DoSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DoSymbol.php
@@ -14,7 +14,7 @@ final class DoSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): DoNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): DoNode
     {
         $tupleCount = count($tuple);
         $stmts = [];

--- a/src/php/Analyzer/TupleSymbol/DoSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DoSymbol.php
@@ -10,7 +10,7 @@ use Phel\Ast\Node;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class DoSymbol
+final class DoSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/DoSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DoSymbol.php
@@ -10,7 +10,7 @@ use Phel\Ast\Node;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class DoSymbol implements TupleToNode
+final class DoSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/FnSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/FnSymbol.php
@@ -12,11 +12,11 @@ use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 use Phel\RecurFrame;
 
-final class FnSymbol implements TupleSymbolToNode
+final class FnSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): FnNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): FnNode
     {
         $tupleCount = count($tuple);
         if ($tupleCount < 2) {

--- a/src/php/Analyzer/TupleSymbol/FnSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/FnSymbol.php
@@ -12,7 +12,7 @@ use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 use Phel\RecurFrame;
 
-final class FnSymbol
+final class FnSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/FnSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/FnSymbol.php
@@ -16,7 +16,7 @@ final class FnSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): FnNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): FnNode
     {
         $tupleCount = count($tuple);
         if ($tupleCount < 2) {

--- a/src/php/Analyzer/TupleSymbol/FnSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/FnSymbol.php
@@ -12,7 +12,7 @@ use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 use Phel\RecurFrame;
 
-final class FnSymbol implements TupleToNode
+final class FnSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
@@ -11,7 +11,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class ForeachSymbol
+final class ForeachSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
@@ -15,7 +15,7 @@ final class ForeachSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): ForeachNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): ForeachNode
     {
         $tupleCount = count($tuple);
         if ($tupleCount < 2) {

--- a/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
@@ -11,11 +11,11 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class ForeachSymbol implements TupleSymbolToNode
+final class ForeachSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): ForeachNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): ForeachNode
     {
         $tupleCount = count($tuple);
         if ($tupleCount < 2) {

--- a/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
@@ -11,7 +11,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class ForeachSymbol implements TupleToNode
+final class ForeachSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/IfSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/IfSymbol.php
@@ -11,7 +11,7 @@ use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class IfSymbol
+final class IfSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/IfSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/IfSymbol.php
@@ -15,7 +15,7 @@ final class IfSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): IfNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): IfNode
     {
         $tupleCount = count($tuple);
         if ($tupleCount < 3 || $tupleCount > 4) {

--- a/src/php/Analyzer/TupleSymbol/IfSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/IfSymbol.php
@@ -11,11 +11,11 @@ use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class IfSymbol implements TupleSymbolToNode
+final class IfSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): IfNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): IfNode
     {
         $tupleCount = count($tuple);
         if ($tupleCount < 3 || $tupleCount > 4) {

--- a/src/php/Analyzer/TupleSymbol/IfSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/IfSymbol.php
@@ -11,7 +11,7 @@ use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class IfSymbol implements TupleToNode
+final class IfSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/InvokeSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/InvokeSymbol.php
@@ -14,7 +14,7 @@ use Phel\Lang\AbstractType;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class InvokeSymbol implements TupleToNode
+final class InvokeSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/InvokeSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/InvokeSymbol.php
@@ -18,7 +18,7 @@ final class InvokeSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): Node
+    public function toNode(Tuple $tuple, NodeEnvironment $env): Node
     {
         $f = $this->analyzer->analyze(
             $tuple[0],

--- a/src/php/Analyzer/TupleSymbol/InvokeSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/InvokeSymbol.php
@@ -14,7 +14,7 @@ use Phel\Lang\AbstractType;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class InvokeSymbol
+final class InvokeSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/InvokeSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/InvokeSymbol.php
@@ -14,11 +14,11 @@ use Phel\Lang\AbstractType;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class InvokeSymbol implements TupleSymbolToNode
+final class InvokeSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): Node
+    public function analyze(Tuple $tuple, NodeEnvironment $env): Node
     {
         $f = $this->analyzer->analyze(
             $tuple[0],

--- a/src/php/Analyzer/TupleSymbol/LetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/LetSymbol.php
@@ -13,11 +13,11 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class LetSymbol implements TupleSymbolToNode
+final class LetSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): LetNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): LetNode
     {
         if (count($tuple) < 2) {
             throw AnalyzerException::withLocation("At least two arguments are required for 'let", $tuple);

--- a/src/php/Analyzer/TupleSymbol/LetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/LetSymbol.php
@@ -17,7 +17,7 @@ final class LetSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): LetNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): LetNode
     {
         if (count($tuple) < 2) {
             throw AnalyzerException::withLocation("At least two arguments are required for 'let", $tuple);

--- a/src/php/Analyzer/TupleSymbol/LetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/LetSymbol.php
@@ -13,7 +13,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class LetSymbol
+final class LetSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/LetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/LetSymbol.php
@@ -13,7 +13,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class LetSymbol implements TupleToNode
+final class LetSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/LoopSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/LoopSymbol.php
@@ -14,7 +14,7 @@ use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 use Phel\RecurFrame;
 
-final class LoopSymbol implements TupleToNode
+final class LoopSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/LoopSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/LoopSymbol.php
@@ -18,7 +18,7 @@ final class LoopSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): LetNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): LetNode
     {
         $tupleCount = count($tuple);
         if (!($tuple[0] instanceof Symbol && $tuple[0]->getName() === Symbol::NAME_LOOP)) {

--- a/src/php/Analyzer/TupleSymbol/LoopSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/LoopSymbol.php
@@ -14,11 +14,11 @@ use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 use Phel\RecurFrame;
 
-final class LoopSymbol implements TupleSymbolToNode
+final class LoopSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): LetNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): LetNode
     {
         $tupleCount = count($tuple);
         if (!($tuple[0] instanceof Symbol && $tuple[0]->getName() === Symbol::NAME_LOOP)) {

--- a/src/php/Analyzer/TupleSymbol/LoopSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/LoopSymbol.php
@@ -14,7 +14,7 @@ use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 use Phel\RecurFrame;
 
-final class LoopSymbol
+final class LoopSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/NsSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/NsSymbol.php
@@ -14,7 +14,7 @@ use Phel\Lang\Table;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class NsSymbol
+final class NsSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/NsSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/NsSymbol.php
@@ -14,11 +14,11 @@ use Phel\Lang\Table;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class NsSymbol implements TupleSymbolToNode
+final class NsSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): NsNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): NsNode
     {
         $tupleCount = count($tuple);
         if (!($tuple[1] instanceof Symbol)) {

--- a/src/php/Analyzer/TupleSymbol/NsSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/NsSymbol.php
@@ -18,7 +18,7 @@ final class NsSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): NsNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): NsNode
     {
         $tupleCount = count($tuple);
         if (!($tuple[1] instanceof Symbol)) {

--- a/src/php/Analyzer/TupleSymbol/NsSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/NsSymbol.php
@@ -14,7 +14,7 @@ use Phel\Lang\Table;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class NsSymbol implements TupleToNode
+final class NsSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/PhpAGetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAGetSymbol.php
@@ -9,11 +9,11 @@ use Phel\Ast\PhpArrayGetNode;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpAGetSymbol implements TupleSymbolToNode
+final class PhpAGetSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): PhpArrayGetNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): PhpArrayGetNode
     {
         return new PhpArrayGetNode(
             $env,

--- a/src/php/Analyzer/TupleSymbol/PhpAGetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAGetSymbol.php
@@ -9,7 +9,7 @@ use Phel\Ast\PhpArrayGetNode;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpAGetSymbol
+final class PhpAGetSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/PhpAGetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAGetSymbol.php
@@ -9,7 +9,7 @@ use Phel\Ast\PhpArrayGetNode;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpAGetSymbol implements TupleToNode
+final class PhpAGetSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/PhpAGetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAGetSymbol.php
@@ -13,7 +13,7 @@ final class PhpAGetSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): PhpArrayGetNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): PhpArrayGetNode
     {
         return new PhpArrayGetNode(
             $env,

--- a/src/php/Analyzer/TupleSymbol/PhpAPushSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAPushSymbol.php
@@ -9,7 +9,7 @@ use Phel\Ast\PhpArrayPushNode;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpAPushSymbol implements TupleToNode
+final class PhpAPushSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/PhpAPushSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAPushSymbol.php
@@ -13,7 +13,7 @@ final class PhpAPushSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): PhpArrayPushNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): PhpArrayPushNode
     {
         return new PhpArrayPushNode(
             $env,

--- a/src/php/Analyzer/TupleSymbol/PhpAPushSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAPushSymbol.php
@@ -9,11 +9,11 @@ use Phel\Ast\PhpArrayPushNode;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpAPushSymbol implements TupleSymbolToNode
+final class PhpAPushSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): PhpArrayPushNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): PhpArrayPushNode
     {
         return new PhpArrayPushNode(
             $env,

--- a/src/php/Analyzer/TupleSymbol/PhpAPushSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAPushSymbol.php
@@ -9,7 +9,7 @@ use Phel\Ast\PhpArrayPushNode;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpAPushSymbol
+final class PhpAPushSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/PhpASetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpASetSymbol.php
@@ -9,7 +9,7 @@ use Phel\Ast\PhpArraySetNode;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpASetSymbol
+final class PhpASetSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/PhpASetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpASetSymbol.php
@@ -9,11 +9,11 @@ use Phel\Ast\PhpArraySetNode;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpASetSymbol implements TupleSymbolToNode
+final class PhpASetSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): PhpArraySetNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): PhpArraySetNode
     {
         return new PhpArraySetNode(
             $env,

--- a/src/php/Analyzer/TupleSymbol/PhpASetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpASetSymbol.php
@@ -13,7 +13,7 @@ final class PhpASetSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): PhpArraySetNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): PhpArraySetNode
     {
         return new PhpArraySetNode(
             $env,

--- a/src/php/Analyzer/TupleSymbol/PhpASetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpASetSymbol.php
@@ -9,7 +9,7 @@ use Phel\Ast\PhpArraySetNode;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpASetSymbol implements TupleToNode
+final class PhpASetSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/PhpAUnsetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAUnsetSymbol.php
@@ -10,11 +10,11 @@ use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpAUnsetSymbol implements TupleSymbolToNode
+final class PhpAUnsetSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): PhpArrayUnsetNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): PhpArrayUnsetNode
     {
         if ($env->getContext() !== NodeEnvironment::CTX_STMT) {
             throw AnalyzerException::withLocation("'php/unset can only be called as Statement and not as Expression", $tuple);

--- a/src/php/Analyzer/TupleSymbol/PhpAUnsetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAUnsetSymbol.php
@@ -14,7 +14,7 @@ final class PhpAUnsetSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): PhpArrayUnsetNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): PhpArrayUnsetNode
     {
         if ($env->getContext() !== NodeEnvironment::CTX_STMT) {
             throw AnalyzerException::withLocation("'php/unset can only be called as Statement and not as Expression", $tuple);

--- a/src/php/Analyzer/TupleSymbol/PhpAUnsetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAUnsetSymbol.php
@@ -10,7 +10,7 @@ use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpAUnsetSymbol
+final class PhpAUnsetSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/PhpAUnsetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAUnsetSymbol.php
@@ -10,7 +10,7 @@ use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpAUnsetSymbol implements TupleToNode
+final class PhpAUnsetSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/PhpNewSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpNewSymbol.php
@@ -10,7 +10,7 @@ use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpNewSymbol
+final class PhpNewSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/PhpNewSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpNewSymbol.php
@@ -10,7 +10,7 @@ use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpNewSymbol implements TupleToNode
+final class PhpNewSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/PhpNewSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpNewSymbol.php
@@ -14,7 +14,7 @@ final class PhpNewSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): PhpNewNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): PhpNewNode
     {
         $tupleCount = count($tuple);
         if ($tupleCount < 2) {

--- a/src/php/Analyzer/TupleSymbol/PhpNewSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpNewSymbol.php
@@ -10,11 +10,11 @@ use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpNewSymbol implements TupleSymbolToNode
+final class PhpNewSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): PhpNewNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): PhpNewNode
     {
         $tupleCount = count($tuple);
         if ($tupleCount < 2) {

--- a/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
@@ -17,7 +17,7 @@ final class PhpObjectCallSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env, bool $isStatic): PhpObjectCallNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env, bool $isStatic): PhpObjectCallNode
     {
         $fnName = $isStatic
             ? Symbol::NAME_PHP_OBJECT_STATIC_CALL

--- a/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Analyzer\TupleSymbol;
 
-use Phel\Analyzer\WithAnalyzer;
+use Phel\Analyzer;
 use Phel\Ast\MethodCallNode;
 use Phel\Ast\PhpObjectCallNode;
 use Phel\Ast\PropertyOrConstantAccessNode;
@@ -15,11 +15,19 @@ use Phel\NodeEnvironment;
 
 final class PhpObjectCallSymbol
 {
-    use WithAnalyzer;
+    private Analyzer $analyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env, bool $isStatic): PhpObjectCallNode
+    private bool $isStatic;
+
+    public function __construct(Analyzer $analyzer, bool $isStatic)
     {
-        $fnName = $isStatic
+        $this->analyzer = $analyzer;
+        $this->isStatic = $isStatic;
+    }
+
+    public function toNode(Tuple $tuple, NodeEnvironment $env): PhpObjectCallNode
+    {
+        $fnName = $this->isStatic
             ? Symbol::NAME_PHP_OBJECT_STATIC_CALL
             : Symbol::NAME_PHP_OBJECT_CALL;
 
@@ -48,7 +56,7 @@ final class PhpObjectCallSymbol
             $env,
             $targetExpr,
             $callExpr,
-            $isStatic,
+            $this->isStatic,
             $methodCall,
             $tuple->getStartLocation()
         );

--- a/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
@@ -13,7 +13,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpObjectCallSymbol implements TupleSymbolToNode
+final class PhpObjectCallSymbol implements TupleSymbolAnalyzer
 {
     private Analyzer $analyzer;
 
@@ -25,7 +25,7 @@ final class PhpObjectCallSymbol implements TupleSymbolToNode
         $this->isStatic = $isStatic;
     }
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): PhpObjectCallNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): PhpObjectCallNode
     {
         $fnName = $this->isStatic
             ? Symbol::NAME_PHP_OBJECT_STATIC_CALL

--- a/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
@@ -13,7 +13,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpObjectCallSymbol
+final class PhpObjectCallSymbol implements TupleToNode
 {
     private Analyzer $analyzer;
 

--- a/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
@@ -13,7 +13,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class PhpObjectCallSymbol implements TupleToNode
+final class PhpObjectCallSymbol implements TupleSymbolToNode
 {
     private Analyzer $analyzer;
 

--- a/src/php/Analyzer/TupleSymbol/QuoteSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/QuoteSymbol.php
@@ -10,7 +10,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class QuoteSymbol implements TupleToNode
+final class QuoteSymbol implements TupleSymbolToNode
 {
     public function toNode(Tuple $tuple, NodeEnvironment $env): QuoteNode
     {

--- a/src/php/Analyzer/TupleSymbol/QuoteSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/QuoteSymbol.php
@@ -12,7 +12,7 @@ use Phel\NodeEnvironment;
 
 final class QuoteSymbol
 {
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): QuoteNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): QuoteNode
     {
         if (!($tuple[0] instanceof Symbol && $tuple[0]->getName() === Symbol::NAME_QUOTE)) {
             throw AnalyzerException::withLocation("This is not a 'quote.", $tuple);

--- a/src/php/Analyzer/TupleSymbol/QuoteSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/QuoteSymbol.php
@@ -10,9 +10,9 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class QuoteSymbol implements TupleSymbolToNode
+final class QuoteSymbol implements TupleSymbolAnalyzer
 {
-    public function toNode(Tuple $tuple, NodeEnvironment $env): QuoteNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): QuoteNode
     {
         if (!($tuple[0] instanceof Symbol && $tuple[0]->getName() === Symbol::NAME_QUOTE)) {
             throw AnalyzerException::withLocation("This is not a 'quote.", $tuple);

--- a/src/php/Analyzer/TupleSymbol/QuoteSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/QuoteSymbol.php
@@ -10,7 +10,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class QuoteSymbol
+final class QuoteSymbol implements TupleToNode
 {
     public function toNode(Tuple $tuple, NodeEnvironment $env): QuoteNode
     {

--- a/src/php/Analyzer/TupleSymbol/RecurSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/RecurSymbol.php
@@ -11,7 +11,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class RecurSymbol implements TupleToNode
+final class RecurSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/RecurSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/RecurSymbol.php
@@ -15,7 +15,7 @@ final class RecurSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): RecurNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): RecurNode
     {
         if (!$this->isValidRecurTuple($tuple)) {
             throw AnalyzerException::withLocation("This is not a 'recur.", $tuple);

--- a/src/php/Analyzer/TupleSymbol/RecurSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/RecurSymbol.php
@@ -11,7 +11,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class RecurSymbol
+final class RecurSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/RecurSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/RecurSymbol.php
@@ -11,11 +11,11 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class RecurSymbol implements TupleSymbolToNode
+final class RecurSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): RecurNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): RecurNode
     {
         if (!$this->isValidRecurTuple($tuple)) {
             throw AnalyzerException::withLocation("This is not a 'recur.", $tuple);

--- a/src/php/Analyzer/TupleSymbol/ThrowSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ThrowSymbol.php
@@ -10,7 +10,7 @@ use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class ThrowSymbol
+final class ThrowSymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/ThrowSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ThrowSymbol.php
@@ -14,7 +14,7 @@ final class ThrowSymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): ThrowNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): ThrowNode
     {
         if (count($tuple) !== 2) {
             throw AnalyzerException::withLocation("Exact one argument is required for 'throw", $tuple);

--- a/src/php/Analyzer/TupleSymbol/ThrowSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ThrowSymbol.php
@@ -10,7 +10,7 @@ use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class ThrowSymbol implements TupleToNode
+final class ThrowSymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/ThrowSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ThrowSymbol.php
@@ -10,11 +10,11 @@ use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class ThrowSymbol implements TupleSymbolToNode
+final class ThrowSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): ThrowNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): ThrowNode
     {
         if (count($tuple) !== 2) {
             throw AnalyzerException::withLocation("Exact one argument is required for 'throw", $tuple);

--- a/src/php/Analyzer/TupleSymbol/TrySymbol.php
+++ b/src/php/Analyzer/TupleSymbol/TrySymbol.php
@@ -12,7 +12,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class TrySymbol
+final class TrySymbol implements TupleToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/TrySymbol.php
+++ b/src/php/Analyzer/TupleSymbol/TrySymbol.php
@@ -12,7 +12,7 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class TrySymbol implements TupleToNode
+final class TrySymbol implements TupleSymbolToNode
 {
     use WithAnalyzer;
 

--- a/src/php/Analyzer/TupleSymbol/TrySymbol.php
+++ b/src/php/Analyzer/TupleSymbol/TrySymbol.php
@@ -16,7 +16,7 @@ final class TrySymbol
 {
     use WithAnalyzer;
 
-    public function __invoke(Tuple $tuple, NodeEnvironment $env): TryNode
+    public function toNode(Tuple $tuple, NodeEnvironment $env): TryNode
     {
         $tupleCount = count($tuple);
         $state = 'start';

--- a/src/php/Analyzer/TupleSymbol/TrySymbol.php
+++ b/src/php/Analyzer/TupleSymbol/TrySymbol.php
@@ -12,11 +12,11 @@ use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-final class TrySymbol implements TupleSymbolToNode
+final class TrySymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function toNode(Tuple $tuple, NodeEnvironment $env): TryNode
+    public function analyze(Tuple $tuple, NodeEnvironment $env): TryNode
     {
         $tupleCount = count($tuple);
         $state = 'start';

--- a/src/php/Analyzer/TupleSymbol/TupleSymbolAnalyzer.php
+++ b/src/php/Analyzer/TupleSymbol/TupleSymbolAnalyzer.php
@@ -8,7 +8,7 @@ use Phel\Ast\Node;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-interface TupleSymbolToNode
+interface TupleSymbolAnalyzer
 {
-    public function toNode(Tuple $tuple, NodeEnvironment $env): Node;
+    public function analyze(Tuple $tuple, NodeEnvironment $env): Node;
 }

--- a/src/php/Analyzer/TupleSymbol/TupleSymbolToNode.php
+++ b/src/php/Analyzer/TupleSymbol/TupleSymbolToNode.php
@@ -8,7 +8,7 @@ use Phel\Ast\Node;
 use Phel\Lang\Tuple;
 use Phel\NodeEnvironment;
 
-interface TupleToNode
+interface TupleSymbolToNode
 {
     public function toNode(Tuple $tuple, NodeEnvironment $env): Node;
 }

--- a/src/php/Analyzer/TupleSymbol/TupleToNode.php
+++ b/src/php/Analyzer/TupleSymbol/TupleToNode.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Analyzer\TupleSymbol;
+
+use Phel\Ast\Node;
+use Phel\Lang\Tuple;
+use Phel\NodeEnvironment;
+
+interface TupleToNode
+{
+    public function toNode(Tuple $tuple, NodeEnvironment $env): Node;
+}

--- a/tests/php/Analyzer/AnalyzeTupleTest.php
+++ b/tests/php/Analyzer/AnalyzeTupleTest.php
@@ -44,55 +44,55 @@ final class AnalyzeTupleTest extends TestCase
     public function testSymbolWithNameDef(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_DEF), Symbol::create('increment'), 'inc');
-        self::assertInstanceOf(DefNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(DefNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameNs(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_NS), Symbol::create('def-ns'));
-        self::assertInstanceOf(NsNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(NsNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameFn(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_FN), Tuple::create());
-        self::assertInstanceOf(FnNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(FnNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameQuote(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_QUOTE), 'any text');
-        self::assertInstanceOf(QuoteNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(QuoteNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameDo(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_DO), 1);
-        self::assertInstanceOf(DoNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(DoNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameIf(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_IF), true, true);
-        self::assertInstanceOf(IfNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(IfNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameApply(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_APPLY), '+', Tuple::create(''));
-        self::assertInstanceOf(ApplyNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(ApplyNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameLet(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_LET), Tuple::create(), Tuple::create());
-        self::assertInstanceOf(LetNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(LetNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNamePhpNew(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_NEW), '');
-        self::assertInstanceOf(PhpNewNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(PhpNewNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNamePhpObjectCall(): void
@@ -100,7 +100,7 @@ final class AnalyzeTupleTest extends TestCase
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_OBJECT_CALL), '', Symbol::create(''));
         self::assertInstanceOf(
             PhpObjectCallNode::class,
-            $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty())
+            $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty())
         );
     }
 
@@ -109,7 +109,7 @@ final class AnalyzeTupleTest extends TestCase
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL), '', Symbol::create(''));
         self::assertInstanceOf(
             PhpObjectCallNode::class,
-            $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty())
+            $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty())
         );
     }
 
@@ -118,7 +118,7 @@ final class AnalyzeTupleTest extends TestCase
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_GET));
         self::assertInstanceOf(
             PhpArrayGetNode::class,
-            $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty())
+            $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty())
         );
     }
 
@@ -127,7 +127,7 @@ final class AnalyzeTupleTest extends TestCase
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_SET));
         self::assertInstanceOf(
             PhpArraySetNode::class,
-            $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty())
+            $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty())
         );
     }
 
@@ -136,7 +136,7 @@ final class AnalyzeTupleTest extends TestCase
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_PUSH));
         self::assertInstanceOf(
             PhpArrayPushNode::class,
-            $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty())
+            $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty())
         );
     }
 
@@ -145,7 +145,7 @@ final class AnalyzeTupleTest extends TestCase
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_UNSET));
         self::assertInstanceOf(
             PhpArrayUnsetNode::class,
-            $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty())
+            $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty())
         );
     }
 
@@ -154,25 +154,25 @@ final class AnalyzeTupleTest extends TestCase
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_RECUR), 1);
         $recurFrames = [new RecurFrame([Symbol::create(Symbol::NAME_FOREACH)])];
         $nodeEnv = new NodeEnvironment([], NodeEnvironment::CTX_STMT, [], $recurFrames);
-        self::assertInstanceOf(RecurNode::class, $this->tupleAnalyzer->__invoke($tuple, $nodeEnv));
+        self::assertInstanceOf(RecurNode::class, $this->tupleAnalyzer->toNode($tuple, $nodeEnv));
     }
 
     public function testSymbolWithNameTry(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_TRY));
-        self::assertInstanceOf(TryNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(TryNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameThrow(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_THROW), '');
-        self::assertInstanceOf(ThrowNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(ThrowNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameLoop(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_LOOP), Tuple::create(), Tuple::create());
-        self::assertInstanceOf(LetNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(LetNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameForeach(): void
@@ -182,12 +182,12 @@ final class AnalyzeTupleTest extends TestCase
             Tuple::create(Symbol::create(''), Tuple::create()),
             Tuple::create()
         );
-        self::assertInstanceOf(ForeachNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(ForeachNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameDefStruct(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_DEF_STRUCT), Symbol::create(''), Tuple::create());
-        self::assertInstanceOf(DefStructNode::class, $this->tupleAnalyzer->__invoke($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(DefStructNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
     }
 }

--- a/tests/php/Analyzer/AnalyzeTupleTest.php
+++ b/tests/php/Analyzer/AnalyzeTupleTest.php
@@ -44,55 +44,55 @@ final class AnalyzeTupleTest extends TestCase
     public function testSymbolWithNameDef(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_DEF), Symbol::create('increment'), 'inc');
-        self::assertInstanceOf(DefNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(DefNode::class, $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameNs(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_NS), Symbol::create('def-ns'));
-        self::assertInstanceOf(NsNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(NsNode::class, $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameFn(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_FN), Tuple::create());
-        self::assertInstanceOf(FnNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(FnNode::class, $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameQuote(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_QUOTE), 'any text');
-        self::assertInstanceOf(QuoteNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(QuoteNode::class, $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameDo(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_DO), 1);
-        self::assertInstanceOf(DoNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(DoNode::class, $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameIf(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_IF), true, true);
-        self::assertInstanceOf(IfNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(IfNode::class, $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameApply(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_APPLY), '+', Tuple::create(''));
-        self::assertInstanceOf(ApplyNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(ApplyNode::class, $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameLet(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_LET), Tuple::create(), Tuple::create());
-        self::assertInstanceOf(LetNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(LetNode::class, $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNamePhpNew(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_NEW), '');
-        self::assertInstanceOf(PhpNewNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(PhpNewNode::class, $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNamePhpObjectCall(): void
@@ -100,7 +100,7 @@ final class AnalyzeTupleTest extends TestCase
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_OBJECT_CALL), '', Symbol::create(''));
         self::assertInstanceOf(
             PhpObjectCallNode::class,
-            $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty())
+            $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty())
         );
     }
 
@@ -109,7 +109,7 @@ final class AnalyzeTupleTest extends TestCase
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL), '', Symbol::create(''));
         self::assertInstanceOf(
             PhpObjectCallNode::class,
-            $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty())
+            $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty())
         );
     }
 
@@ -118,7 +118,7 @@ final class AnalyzeTupleTest extends TestCase
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_GET));
         self::assertInstanceOf(
             PhpArrayGetNode::class,
-            $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty())
+            $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty())
         );
     }
 
@@ -127,7 +127,7 @@ final class AnalyzeTupleTest extends TestCase
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_SET));
         self::assertInstanceOf(
             PhpArraySetNode::class,
-            $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty())
+            $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty())
         );
     }
 
@@ -136,7 +136,7 @@ final class AnalyzeTupleTest extends TestCase
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_PUSH));
         self::assertInstanceOf(
             PhpArrayPushNode::class,
-            $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty())
+            $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty())
         );
     }
 
@@ -145,7 +145,7 @@ final class AnalyzeTupleTest extends TestCase
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_PHP_ARRAY_UNSET));
         self::assertInstanceOf(
             PhpArrayUnsetNode::class,
-            $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty())
+            $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty())
         );
     }
 
@@ -154,25 +154,25 @@ final class AnalyzeTupleTest extends TestCase
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_RECUR), 1);
         $recurFrames = [new RecurFrame([Symbol::create(Symbol::NAME_FOREACH)])];
         $nodeEnv = new NodeEnvironment([], NodeEnvironment::CTX_STMT, [], $recurFrames);
-        self::assertInstanceOf(RecurNode::class, $this->tupleAnalyzer->toNode($tuple, $nodeEnv));
+        self::assertInstanceOf(RecurNode::class, $this->tupleAnalyzer->analyze($tuple, $nodeEnv));
     }
 
     public function testSymbolWithNameTry(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_TRY));
-        self::assertInstanceOf(TryNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(TryNode::class, $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameThrow(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_THROW), '');
-        self::assertInstanceOf(ThrowNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(ThrowNode::class, $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameLoop(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_LOOP), Tuple::create(), Tuple::create());
-        self::assertInstanceOf(LetNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(LetNode::class, $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameForeach(): void
@@ -182,12 +182,12 @@ final class AnalyzeTupleTest extends TestCase
             Tuple::create(Symbol::create(''), Tuple::create()),
             Tuple::create()
         );
-        self::assertInstanceOf(ForeachNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(ForeachNode::class, $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty()));
     }
 
     public function testSymbolWithNameDefStruct(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_DEF_STRUCT), Symbol::create(''), Tuple::create());
-        self::assertInstanceOf(DefStructNode::class, $this->tupleAnalyzer->toNode($tuple, NodeEnvironment::empty()));
+        self::assertInstanceOf(DefStructNode::class, $this->tupleAnalyzer->analyze($tuple, NodeEnvironment::empty()));
     }
 }

--- a/tests/php/Analyzer/TupleSymbol/ApplySymbolTest.php
+++ b/tests/php/Analyzer/TupleSymbol/ApplySymbolTest.php
@@ -32,7 +32,7 @@ final class ApplySymbolTest extends TestCase
             Symbol::create(Symbol::NAME_APPLY),
             Symbol::create('\\')
         );
-        (new ApplySymbol($this->analyzer))->toNode($tuple, NodeEnvironment::empty());
+        (new ApplySymbol($this->analyzer))->analyze($tuple, NodeEnvironment::empty());
     }
 
     public function testApplyNode(): void
@@ -42,7 +42,7 @@ final class ApplySymbolTest extends TestCase
             '+',
             Tuple::create('1', '2', '3')
         );
-        $applyNode = (new ApplySymbol($this->analyzer))->toNode($tuple, NodeEnvironment::empty());
+        $applyNode = (new ApplySymbol($this->analyzer))->analyze($tuple, NodeEnvironment::empty());
 
         self::assertSame('+', ($applyNode->getFn())->getValue());
         self::assertInstanceOf(CallNode::class, $applyNode->getArguments()[0]);

--- a/tests/php/Analyzer/TupleSymbol/ApplySymbolTest.php
+++ b/tests/php/Analyzer/TupleSymbol/ApplySymbolTest.php
@@ -32,7 +32,7 @@ final class ApplySymbolTest extends TestCase
             Symbol::create(Symbol::NAME_APPLY),
             Symbol::create('\\')
         );
-        (new ApplySymbol($this->analyzer))($tuple, NodeEnvironment::empty());
+        (new ApplySymbol($this->analyzer))->toNode($tuple, NodeEnvironment::empty());
     }
 
     public function testApplyNode(): void
@@ -42,7 +42,7 @@ final class ApplySymbolTest extends TestCase
             '+',
             Tuple::create('1', '2', '3')
         );
-        $applyNode = (new ApplySymbol($this->analyzer))($tuple, NodeEnvironment::empty());
+        $applyNode = (new ApplySymbol($this->analyzer))->toNode($tuple, NodeEnvironment::empty());
 
         self::assertSame('+', ($applyNode->getFn())->getValue());
         self::assertInstanceOf(CallNode::class, $applyNode->getArguments()[0]);

--- a/tests/php/Analyzer/TupleSymbol/DefStructSymbolTest.php
+++ b/tests/php/Analyzer/TupleSymbol/DefStructSymbolTest.php
@@ -32,7 +32,7 @@ final class DefStructSymbolTest extends TestCase
         );
 
         (new DefStructSymbol($this->analyzer))
-            ->toNode($tuple, NodeEnvironment::empty());
+            ->analyze($tuple, NodeEnvironment::empty());
     }
 
     public function testFirstArgIsNotSymbol(): void
@@ -47,7 +47,7 @@ final class DefStructSymbolTest extends TestCase
         );
 
         (new DefStructSymbol($this->analyzer))
-            ->toNode($tuple, NodeEnvironment::empty());
+            ->analyze($tuple, NodeEnvironment::empty());
     }
 
     public function testSecondArgIsNotTuple(): void
@@ -62,7 +62,7 @@ final class DefStructSymbolTest extends TestCase
         );
 
         (new DefStructSymbol($this->analyzer))
-            ->toNode($tuple, NodeEnvironment::empty());
+            ->analyze($tuple, NodeEnvironment::empty());
     }
 
     public function testTupleElemsAreNotSymbols(): void
@@ -77,7 +77,7 @@ final class DefStructSymbolTest extends TestCase
         );
 
         (new DefStructSymbol($this->analyzer))
-            ->toNode($tuple, NodeEnvironment::empty());
+            ->analyze($tuple, NodeEnvironment::empty());
     }
 
     public function testDefStructSymbol(): void
@@ -89,7 +89,7 @@ final class DefStructSymbolTest extends TestCase
         );
 
         $defStructNode = (new DefStructSymbol($this->analyzer))
-            ->toNode($tuple, NodeEnvironment::empty());
+            ->analyze($tuple, NodeEnvironment::empty());
 
         self::assertSame('request', $defStructNode->getName()->getName());
         self::assertSame('user', $defStructNode->getNamespace());

--- a/tests/php/Analyzer/TupleSymbol/DefStructSymbolTest.php
+++ b/tests/php/Analyzer/TupleSymbol/DefStructSymbolTest.php
@@ -30,7 +30,9 @@ final class DefStructSymbolTest extends TestCase
         $tuple = Tuple::create(
             Symbol::create(Symbol::NAME_DEF_STRUCT),
         );
-        (new DefStructSymbol($this->analyzer))($tuple, NodeEnvironment::empty());
+
+        (new DefStructSymbol($this->analyzer))
+            ->toNode($tuple, NodeEnvironment::empty());
     }
 
     public function testFirstArgIsNotSymbol(): void
@@ -43,7 +45,9 @@ final class DefStructSymbolTest extends TestCase
             '',
             Tuple::create()
         );
-        (new DefStructSymbol($this->analyzer))($tuple, NodeEnvironment::empty());
+
+        (new DefStructSymbol($this->analyzer))
+            ->toNode($tuple, NodeEnvironment::empty());
     }
 
     public function testSecondArgIsNotTuple(): void
@@ -56,7 +60,9 @@ final class DefStructSymbolTest extends TestCase
             Symbol::create('request'),
             ''
         );
-        (new DefStructSymbol($this->analyzer))($tuple, NodeEnvironment::empty());
+
+        (new DefStructSymbol($this->analyzer))
+            ->toNode($tuple, NodeEnvironment::empty());
     }
 
     public function testTupleElemsAreNotSymbols(): void
@@ -69,7 +75,9 @@ final class DefStructSymbolTest extends TestCase
             Symbol::create('request'),
             Tuple::create('method')
         );
-        (new DefStructSymbol($this->analyzer))($tuple, NodeEnvironment::empty());
+
+        (new DefStructSymbol($this->analyzer))
+            ->toNode($tuple, NodeEnvironment::empty());
     }
 
     public function testDefStructSymbol(): void
@@ -79,7 +87,9 @@ final class DefStructSymbolTest extends TestCase
             Symbol::create('request'),
             Tuple::create(Symbol::create('method'), Symbol::create('uri'))
         );
-        $defStructNode = (new DefStructSymbol($this->analyzer))($tuple, NodeEnvironment::empty());
+
+        $defStructNode = (new DefStructSymbol($this->analyzer))
+            ->toNode($tuple, NodeEnvironment::empty());
 
         self::assertSame('request', $defStructNode->getName()->getName());
         self::assertSame('user', $defStructNode->getNamespace());

--- a/tests/php/Analyzer/TupleSymbol/DefSymbolTest.php
+++ b/tests/php/Analyzer/TupleSymbol/DefSymbolTest.php
@@ -30,7 +30,7 @@ final class DefSymbolTest extends TestCase
         $this->expectExceptionMessage("'def inside of a 'def is forbidden");
 
         $env = NodeEnvironment::empty()->withDefAllowed(false);
-        (new DefSymbol($this->analyzer))->toNode(Tuple::create(), $env);
+        (new DefSymbol($this->analyzer))->analyze(Tuple::create(), $env);
     }
 
     public function testEnsureDefIsNotAllowedInsideADefSymbol(): void
@@ -40,8 +40,8 @@ final class DefSymbolTest extends TestCase
 
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_DEF), Symbol::create('1'), 'any value');
         $env = NodeEnvironment::empty();
-        $defNode = (new DefSymbol($this->analyzer))->toNode($tuple, $env);
-        (new DefSymbol($this->analyzer))->toNode($tuple, $defNode->getInit()->getEnv());
+        $defNode = (new DefSymbol($this->analyzer))->analyze($tuple, $env);
+        (new DefSymbol($this->analyzer))->analyze($tuple, $defNode->getInit()->getEnv());
     }
 
     public function testWithWrongNumberOfArguments(): void
@@ -50,7 +50,7 @@ final class DefSymbolTest extends TestCase
         $this->expectExceptionMessage("Two or three arguments are required for 'def. Got 2");
 
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_DEF), Symbol::create('1'));
-        (new DefSymbol($this->analyzer))->toNode($tuple, NodeEnvironment::empty());
+        (new DefSymbol($this->analyzer))->analyze($tuple, NodeEnvironment::empty());
     }
 
     public function testFirstArgumentMustBeSymbol(): void
@@ -59,14 +59,14 @@ final class DefSymbolTest extends TestCase
         $this->expectExceptionMessage("First argument of 'def must be a Symbol.");
 
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_DEF), 'not a symbol', '2');
-        (new DefSymbol($this->analyzer))->toNode($tuple, NodeEnvironment::empty());
+        (new DefSymbol($this->analyzer))->analyze($tuple, NodeEnvironment::empty());
     }
 
     public function testMetaAndInitValues(): void
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_DEF), Symbol::create('1'), 'any value');
         $env = NodeEnvironment::empty();
-        $defNode = (new DefSymbol($this->analyzer))->toNode($tuple, $env);
+        $defNode = (new DefSymbol($this->analyzer))->analyze($tuple, $env);
 
         self::assertEquals(Table::fromKVs(), $defNode->getMeta());
 

--- a/tests/php/Analyzer/TupleSymbol/PhpObjectCallSymbolTest.php
+++ b/tests/php/Analyzer/TupleSymbol/PhpObjectCallSymbolTest.php
@@ -34,7 +34,9 @@ final class PhpObjectCallSymbolTest extends TestCase
             Symbol::create(Symbol::NAME_PHP_OBJECT_STATIC_CALL),
             Symbol::create('\\')
         );
-        (new PhpObjectCallSymbol($this->analyzer))($tuple, NodeEnvironment::empty(), $isStatic = true);
+
+        (new PhpObjectCallSymbol($this->analyzer))
+            ->toNode($tuple, NodeEnvironment::empty(), $isStatic = true);
     }
 
     public function testTupleWithWrongSymbol(): void
@@ -47,7 +49,8 @@ final class PhpObjectCallSymbolTest extends TestCase
             Symbol::create('\\'),
             ''
         );
-        (new PhpObjectCallSymbol($this->analyzer))($tuple, NodeEnvironment::empty(), $isStatic = false);
+        (new PhpObjectCallSymbol($this->analyzer))
+            ->toNode($tuple, NodeEnvironment::empty(), $isStatic = false);
     }
 
     public function testIsStatic(): void
@@ -57,7 +60,8 @@ final class PhpObjectCallSymbolTest extends TestCase
             Symbol::create('\\'),
             Symbol::create('')
         );
-        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))($tuple, NodeEnvironment::empty(), $isStatic = true);
+        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))
+            ->toNode($tuple, NodeEnvironment::empty(), $isStatic = true);
         self::assertSame($isStatic, $objCallNode->isStatic());
         self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
         self::assertInstanceOf(PropertyOrConstantAccessNode::class, $objCallNode->getCallExpr());
@@ -70,7 +74,10 @@ final class PhpObjectCallSymbolTest extends TestCase
             Symbol::create('\\'),
             Symbol::create('')
         );
-        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))($tuple, NodeEnvironment::empty(), $isStatic = false);
+
+        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))
+            ->toNode($tuple, NodeEnvironment::empty(), $isStatic = false);
+
         self::assertSame($isStatic, $objCallNode->isStatic());
         self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
         self::assertInstanceOf(PropertyOrConstantAccessNode::class, $objCallNode->getCallExpr());
@@ -83,7 +90,10 @@ final class PhpObjectCallSymbolTest extends TestCase
             Symbol::create('\\'),
             Tuple::create(Symbol::create(''), '', '')
         );
-        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))($tuple, NodeEnvironment::empty(), $isStatic = true);
+
+        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))
+            ->toNode($tuple, NodeEnvironment::empty(), $isStatic = true);
+
         self::assertTrue($objCallNode->isMethodCall());
         self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
         self::assertInstanceOf(MethodCallNode::class, $objCallNode->getCallExpr());
@@ -96,7 +106,10 @@ final class PhpObjectCallSymbolTest extends TestCase
             Symbol::create('\\'),
             Symbol::create('')
         );
-        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))($tuple, NodeEnvironment::empty(), $isStatic = true);
+
+        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))
+            ->toNode($tuple, NodeEnvironment::empty(), $isStatic = true);
+
         self::assertFalse($objCallNode->isMethodCall());
         self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
         self::assertInstanceOf(PropertyOrConstantAccessNode::class, $objCallNode->getCallExpr());

--- a/tests/php/Analyzer/TupleSymbol/PhpObjectCallSymbolTest.php
+++ b/tests/php/Analyzer/TupleSymbol/PhpObjectCallSymbolTest.php
@@ -35,8 +35,8 @@ final class PhpObjectCallSymbolTest extends TestCase
             Symbol::create('\\')
         );
 
-        (new PhpObjectCallSymbol($this->analyzer))
-            ->toNode($tuple, NodeEnvironment::empty(), $isStatic = true);
+        (new PhpObjectCallSymbol($this->analyzer, $isStatic = true))
+            ->toNode($tuple, NodeEnvironment::empty());
     }
 
     public function testTupleWithWrongSymbol(): void
@@ -49,8 +49,8 @@ final class PhpObjectCallSymbolTest extends TestCase
             Symbol::create('\\'),
             ''
         );
-        (new PhpObjectCallSymbol($this->analyzer))
-            ->toNode($tuple, NodeEnvironment::empty(), $isStatic = false);
+        (new PhpObjectCallSymbol($this->analyzer, $isStatic = false))
+            ->toNode($tuple, NodeEnvironment::empty());
     }
 
     public function testIsStatic(): void
@@ -60,8 +60,8 @@ final class PhpObjectCallSymbolTest extends TestCase
             Symbol::create('\\'),
             Symbol::create('')
         );
-        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))
-            ->toNode($tuple, NodeEnvironment::empty(), $isStatic = true);
+        $objCallNode = (new PhpObjectCallSymbol($this->analyzer, $isStatic = true))
+            ->toNode($tuple, NodeEnvironment::empty());
         self::assertSame($isStatic, $objCallNode->isStatic());
         self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
         self::assertInstanceOf(PropertyOrConstantAccessNode::class, $objCallNode->getCallExpr());
@@ -75,8 +75,8 @@ final class PhpObjectCallSymbolTest extends TestCase
             Symbol::create('')
         );
 
-        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))
-            ->toNode($tuple, NodeEnvironment::empty(), $isStatic = false);
+        $objCallNode = (new PhpObjectCallSymbol($this->analyzer, $isStatic = false))
+            ->toNode($tuple, NodeEnvironment::empty());
 
         self::assertSame($isStatic, $objCallNode->isStatic());
         self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
@@ -91,8 +91,8 @@ final class PhpObjectCallSymbolTest extends TestCase
             Tuple::create(Symbol::create(''), '', '')
         );
 
-        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))
-            ->toNode($tuple, NodeEnvironment::empty(), $isStatic = true);
+        $objCallNode = (new PhpObjectCallSymbol($this->analyzer, $isStatic = true))
+            ->toNode($tuple, NodeEnvironment::empty());
 
         self::assertTrue($objCallNode->isMethodCall());
         self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
@@ -107,8 +107,8 @@ final class PhpObjectCallSymbolTest extends TestCase
             Symbol::create('')
         );
 
-        $objCallNode = (new PhpObjectCallSymbol($this->analyzer))
-            ->toNode($tuple, NodeEnvironment::empty(), $isStatic = true);
+        $objCallNode = (new PhpObjectCallSymbol($this->analyzer, $isStatic = true))
+            ->toNode($tuple, NodeEnvironment::empty());
 
         self::assertFalse($objCallNode->isMethodCall());
         self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());

--- a/tests/php/Analyzer/TupleSymbol/PhpObjectCallSymbolTest.php
+++ b/tests/php/Analyzer/TupleSymbol/PhpObjectCallSymbolTest.php
@@ -36,7 +36,7 @@ final class PhpObjectCallSymbolTest extends TestCase
         );
 
         (new PhpObjectCallSymbol($this->analyzer, $isStatic = true))
-            ->toNode($tuple, NodeEnvironment::empty());
+            ->analyze($tuple, NodeEnvironment::empty());
     }
 
     public function testTupleWithWrongSymbol(): void
@@ -50,7 +50,7 @@ final class PhpObjectCallSymbolTest extends TestCase
             ''
         );
         (new PhpObjectCallSymbol($this->analyzer, $isStatic = false))
-            ->toNode($tuple, NodeEnvironment::empty());
+            ->analyze($tuple, NodeEnvironment::empty());
     }
 
     public function testIsStatic(): void
@@ -61,7 +61,7 @@ final class PhpObjectCallSymbolTest extends TestCase
             Symbol::create('')
         );
         $objCallNode = (new PhpObjectCallSymbol($this->analyzer, $isStatic = true))
-            ->toNode($tuple, NodeEnvironment::empty());
+            ->analyze($tuple, NodeEnvironment::empty());
         self::assertSame($isStatic, $objCallNode->isStatic());
         self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
         self::assertInstanceOf(PropertyOrConstantAccessNode::class, $objCallNode->getCallExpr());
@@ -76,7 +76,7 @@ final class PhpObjectCallSymbolTest extends TestCase
         );
 
         $objCallNode = (new PhpObjectCallSymbol($this->analyzer, $isStatic = false))
-            ->toNode($tuple, NodeEnvironment::empty());
+            ->analyze($tuple, NodeEnvironment::empty());
 
         self::assertSame($isStatic, $objCallNode->isStatic());
         self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
@@ -92,7 +92,7 @@ final class PhpObjectCallSymbolTest extends TestCase
         );
 
         $objCallNode = (new PhpObjectCallSymbol($this->analyzer, $isStatic = true))
-            ->toNode($tuple, NodeEnvironment::empty());
+            ->analyze($tuple, NodeEnvironment::empty());
 
         self::assertTrue($objCallNode->isMethodCall());
         self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());
@@ -108,7 +108,7 @@ final class PhpObjectCallSymbolTest extends TestCase
         );
 
         $objCallNode = (new PhpObjectCallSymbol($this->analyzer, $isStatic = true))
-            ->toNode($tuple, NodeEnvironment::empty());
+            ->analyze($tuple, NodeEnvironment::empty());
 
         self::assertFalse($objCallNode->isMethodCall());
         self::assertInstanceOf(PhpClassNameNode::class, $objCallNode->getTargetExpr());

--- a/tests/php/Analyzer/TupleSymbol/QuoteSymbolTest.php
+++ b/tests/php/Analyzer/TupleSymbol/QuoteSymbolTest.php
@@ -19,7 +19,7 @@ final class QuoteSymbolTest extends TestCase
         $this->expectExceptionMessage("This is not a 'quote.");
 
         $tuple = new Tuple(['any symbol', 'any text']);
-        (new QuoteSymbol())->toNode($tuple, NodeEnvironment::empty());
+        (new QuoteSymbol())->analyze($tuple, NodeEnvironment::empty());
     }
 
     public function testTupleWithoutArgument(): void
@@ -28,13 +28,13 @@ final class QuoteSymbolTest extends TestCase
         $this->expectExceptionMessage("Exactly one argument is required for 'quote");
 
         $tuple = new Tuple([Symbol::create(Symbol::NAME_QUOTE)]);
-        (new QuoteSymbol())->toNode($tuple, NodeEnvironment::empty());
+        (new QuoteSymbol())->analyze($tuple, NodeEnvironment::empty());
     }
 
     public function testQuoteTupleWithAnyText(): void
     {
         $tuple = new Tuple([Symbol::create(Symbol::NAME_QUOTE), 'any text']);
-        $symbol = (new QuoteSymbol())->toNode($tuple, NodeEnvironment::empty());
+        $symbol = (new QuoteSymbol())->analyze($tuple, NodeEnvironment::empty());
 
         self::assertSame('any text', $symbol->getValue());
     }

--- a/tests/php/Analyzer/TupleSymbol/QuoteSymbolTest.php
+++ b/tests/php/Analyzer/TupleSymbol/QuoteSymbolTest.php
@@ -19,7 +19,7 @@ final class QuoteSymbolTest extends TestCase
         $this->expectExceptionMessage("This is not a 'quote.");
 
         $tuple = new Tuple(['any symbol', 'any text']);
-        (new QuoteSymbol())($tuple, NodeEnvironment::empty());
+        (new QuoteSymbol())->toNode($tuple, NodeEnvironment::empty());
     }
 
     public function testTupleWithoutArgument(): void
@@ -28,13 +28,13 @@ final class QuoteSymbolTest extends TestCase
         $this->expectExceptionMessage("Exactly one argument is required for 'quote");
 
         $tuple = new Tuple([Symbol::create(Symbol::NAME_QUOTE)]);
-        (new QuoteSymbol())($tuple, NodeEnvironment::empty());
+        (new QuoteSymbol())->toNode($tuple, NodeEnvironment::empty());
     }
 
     public function testQuoteTupleWithAnyText(): void
     {
         $tuple = new Tuple([Symbol::create(Symbol::NAME_QUOTE), 'any text']);
-        $symbol = (new QuoteSymbol())($tuple, NodeEnvironment::empty());
+        $symbol = (new QuoteSymbol())->toNode($tuple, NodeEnvironment::empty());
 
         self::assertSame('any text', $symbol->getValue());
     }


### PR DESCRIPTION
# Description

In order to improve readability I renamed the `__invoke()` functions to use `analyze()` instead.

# Changes

- Use `analyze()` instead of `__invoke()` for the Analyzer objects and TupleSymbol.
- Introduce an interface (`TupleSymbolAnalyzer`) for all `TupleSymbol` so they are easier to build. 
  - Look the refactoring done in `AnalyzeTuple`.