### PR TITLE
Added no_unused_imports to php_cs

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -21,6 +21,7 @@ return PhpCsFixer\Config::create()
     'no_empty_statement' => true,
     'no_leading_import_slash' => true,
     'no_leading_namespace_whitespace' => true,
+    'no_unused_imports' => true,
     'no_whitespace_in_blank_line' => true,
     'return_type_declaration' => ['space_before' => 'none'],
     'single_trait_insert_per_statement' => true,

--- a/src/php/Destructure.php
+++ b/src/php/Destructure.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phel;
 
-use Exception;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\AbstractType;
 use Phel\Lang\PhelArray;

--- a/src/php/Printer.php
+++ b/src/php/Printer.php
@@ -6,7 +6,6 @@ namespace Phel;
 
 use Exception;
 use Phel\Lang\Keyword;
-use Phel\Lang\AbstractType;
 use Phel\Lang\PhelArray;
 use Phel\Lang\Struct;
 use Phel\Lang\Symbol;

--- a/src/php/ReaderResult.php
+++ b/src/php/ReaderResult.php
@@ -3,7 +3,6 @@
 namespace Phel;
 
 use Phel\Lang\AbstractType;
-use Phel\CodeSnippet;
 
 class ReaderResult
 {


### PR DESCRIPTION
# Description

Added the no_unused_imports rule to the PHP Code Syle fixer

# Changes

- Added `no_unused_imports` to the `php_cs.dist`
- Applied the fixer