### PR TITLE
Rename CTX_* constants by CONTEXT_*

### DIFF
--- a/src/php/Analyzer/AnalyzeArray.php
+++ b/src/php/Analyzer/AnalyzeArray.php
@@ -15,7 +15,7 @@ final class AnalyzeArray
     public function analyze(PhelArray $array, NodeEnvironment $env): ArrayNode
     {
         $values = [];
-        $valueEnv = $env->withContext(NodeEnvironment::CTX_EXPR);
+        $valueEnv = $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION);
 
         foreach ($array as $value) {
             $values[] = $this->analyzer->analyze($value, $valueEnv);

--- a/src/php/Analyzer/AnalyzeBracketTuple.php
+++ b/src/php/Analyzer/AnalyzeBracketTuple.php
@@ -17,7 +17,7 @@ final class AnalyzeBracketTuple
         $args = [];
 
         foreach ($tuple as $arg) {
-            $envDisallowRecur = $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame();
+            $envDisallowRecur = $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame();
             $args[] = $this->analyzer->analyze($arg, $envDisallowRecur);
         }
 

--- a/src/php/Analyzer/AnalyzeTable.php
+++ b/src/php/Analyzer/AnalyzeTable.php
@@ -15,7 +15,7 @@ final class AnalyzeTable
     public function analyze(Table $table, NodeEnvironment $env): TableNode
     {
         $keyValues = [];
-        $kvEnv = $env->withContext(NodeEnvironment::CTX_EXPR);
+        $kvEnv = $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION);
 
         foreach ($table as $key => $value) {
             $keyValues[] = $this->analyzer->analyze($key, $kvEnv);

--- a/src/php/Analyzer/TupleSymbol/ApplySymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ApplySymbol.php
@@ -42,7 +42,7 @@ final class ApplySymbol implements TupleSymbolAnalyzer
     {
         return $this->analyzer->analyze(
             $x,
-            $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()
+            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
         );
     }
 

--- a/src/php/Analyzer/TupleSymbol/DefSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DefSymbol.php
@@ -127,7 +127,7 @@ final class DefSymbol implements TupleSymbolAnalyzer
     {
         $initEnv = $env
             ->withBoundTo($namespace . '\\' . $nameSymbol)
-            ->withContext(NodeEnvironment::CTX_EXPR)
+            ->withContext(NodeEnvironment::CONTEXT_EXPRESSION)
             ->withDisallowRecurFrame()
             ->withDefAllowed(false);
 

--- a/src/php/Analyzer/TupleSymbol/DoSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DoSymbol.php
@@ -27,7 +27,7 @@ final class DoSymbol implements TupleSymbolAnalyzer
         for ($i = 1; $i < $tupleCount - 1; $i++) {
             $stmts[] = $this->analyzer->analyze(
                 $tuple[$i],
-                $env->withContext(NodeEnvironment::CTX_STMT)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironment::CONTEXT_STATEMENT)->withDisallowRecurFrame()
             );
         }
 
@@ -44,9 +44,9 @@ final class DoSymbol implements TupleSymbolAnalyzer
         $tupleCount = count($tuple);
 
         if ($tupleCount > 2) {
-            $retEnv = $env->getContext() === NodeEnvironment::CTX_STMT
-                ? $env->withContext(NodeEnvironment::CTX_STMT)
-                : $env->withContext(NodeEnvironment::CTX_RET);
+            $retEnv = $env->getContext() === NodeEnvironment::CONTEXT_STATEMENT
+                ? $env->withContext(NodeEnvironment::CONTEXT_STATEMENT)
+                : $env->withContext(NodeEnvironment::CONTEXT_RETURN);
 
             return $this->analyzer->analyze($tuple[$tupleCount - 1], $retEnv);
         }

--- a/src/php/Analyzer/TupleSymbol/FnSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/FnSymbol.php
@@ -168,7 +168,7 @@ final class FnSymbol implements TupleSymbolAnalyzer
 
         $bodyEnv = $env
             ->withMergedLocals($this->params)
-            ->withContext(NodeEnvironment::CTX_RET)
+            ->withContext(NodeEnvironment::CONTEXT_RETURN)
             ->withAddedRecurFrame($recurFrame);
 
         return $this->analyzer->analyze($body, $bodyEnv);

--- a/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
@@ -45,7 +45,7 @@ final class ForeachSymbol implements TupleSymbolAnalyzer
             $bodyEnv = $env->withMergedLocals([$valueSymbol]);
             $listExpr = $this->analyzer->analyze(
                 $tuple[1][1],
-                $env->withContext(NodeEnvironment::CTX_EXPR)
+                $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)
             );
         } else {
             $keySymbol = $tuple[1][0];
@@ -67,7 +67,7 @@ final class ForeachSymbol implements TupleSymbolAnalyzer
             $bodyEnv = $env->withMergedLocals([$valueSymbol, $keySymbol]);
             $listExpr = $this->analyzer->analyze(
                 $tuple[1][2],
-                $env->withContext(NodeEnvironment::CTX_EXPR)
+                $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)
             );
         }
 
@@ -84,7 +84,7 @@ final class ForeachSymbol implements TupleSymbolAnalyzer
 
         $bodyExpr = $this->analyzer->analyze(
             $body,
-            $bodyEnv->withContext(NodeEnvironment::CTX_STMT)
+            $bodyEnv->withContext(NodeEnvironment::CONTEXT_STATEMENT)
         );
 
         return new ForeachNode(

--- a/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ForeachSymbol.php
@@ -26,7 +26,7 @@ final class ForeachSymbol implements TupleSymbolAnalyzer
 
         $bodyExpr = $this->analyzer->analyze(
             $this->buildTupleBody($foreachSymbolTuple->lets(), $tuple),
-            $foreachSymbolTuple->bodyEnv()->withContext(NodeEnvironment::CTX_STMT)
+            $foreachSymbolTuple->bodyEnv()->withContext(NodeEnvironment::CONTEXT_STATEMENT)
         );
 
         return new ForeachNode(
@@ -79,7 +79,7 @@ final class ForeachSymbol implements TupleSymbolAnalyzer
         $bodyEnv = $env->withMergedLocals([$valueSymbol]);
         $listExpr = $this->analyzer->analyze(
             $foreachTuple[1],
-            $env->withContext(NodeEnvironment::CTX_EXPR)
+            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)
         );
 
         return new ForeachSymbolTuple($lets, $bodyEnv, $listExpr, $valueSymbol);
@@ -107,7 +107,7 @@ final class ForeachSymbol implements TupleSymbolAnalyzer
         $bodyEnv = $env->withMergedLocals([$valueSymbol, $keySymbol]);
         $listExpr = $this->analyzer->analyze(
             $foreachTuple[2],
-            $env->withContext(NodeEnvironment::CTX_EXPR)
+            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)
         );
 
         return new ForeachSymbolTuple($lets, $bodyEnv, $listExpr, $valueSymbol, $keySymbol);

--- a/src/php/Analyzer/TupleSymbol/IfSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/IfSymbol.php
@@ -24,7 +24,7 @@ final class IfSymbol implements TupleSymbolAnalyzer
 
         $testExpr = $this->analyzer->analyze(
             $tuple[1],
-            $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()
+            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
         );
         $thenExpr = $this->analyzer->analyze($tuple[2], $env);
         $elseExpr = $this->elseExpr($tuple, $env);

--- a/src/php/Analyzer/TupleSymbol/InvokeSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/InvokeSymbol.php
@@ -22,7 +22,7 @@ final class InvokeSymbol implements TupleSymbolAnalyzer
     {
         $f = $this->analyzer->analyze(
             $tuple[0],
-            $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()
+            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
         );
 
         if ($f instanceof GlobalVarNode && $f->isMacro()) {
@@ -118,7 +118,7 @@ final class InvokeSymbol implements TupleSymbolAnalyzer
         for ($i = 1, $iMax = count($tuple); $i < $iMax; $i++) {
             $arguments[] = $this->analyzer->analyze(
                 $tuple[$i],
-                $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
             );
         }
 

--- a/src/php/Analyzer/TupleSymbol/LetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/LetSymbol.php
@@ -62,8 +62,8 @@ final class LetSymbol implements TupleSymbolAnalyzer
         $bodyEnv = $env
             ->withMergedLocals($locals)
             ->withContext(
-                $env->getContext() === NodeEnvironment::CTX_EXPR
-                    ? NodeEnvironment::CTX_RET
+                $env->getContext() === NodeEnvironment::CONTEXT_EXPRESSION
+                    ? NodeEnvironment::CONTEXT_RETURN
                     : $env->getContext()
             );
 
@@ -86,7 +86,7 @@ final class LetSymbol implements TupleSymbolAnalyzer
     private function analyzeBindings(Tuple $tuple, NodeEnvironment $env): array
     {
         $tupleCount = count($tuple);
-        $initEnv = $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame();
+        $initEnv = $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame();
         $nodes = [];
         for ($i = 0; $i < $tupleCount; $i += 2) {
             $sym = $tuple[$i];

--- a/src/php/Analyzer/TupleSymbol/LoopSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/LoopSymbol.php
@@ -96,8 +96,8 @@ final class LoopSymbol implements TupleSymbolAnalyzer
         $bodyEnv = $env
             ->withMergedLocals($locals)
             ->withContext(
-                $env->getContext() === NodeEnvironment::CTX_EXPR
-                    ? NodeEnvironment::CTX_RET
+                $env->getContext() === NodeEnvironment::CONTEXT_EXPRESSION
+                    ? NodeEnvironment::CONTEXT_RETURN
                     : $env->getContext()
             );
 
@@ -122,7 +122,7 @@ final class LoopSymbol implements TupleSymbolAnalyzer
     private function analyzeBindings(Tuple $tuple, NodeEnvironment $env): array
     {
         $tupleCount = count($tuple);
-        $initEnv = $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame();
+        $initEnv = $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame();
         $nodes = [];
         for ($i = 0; $i < $tupleCount; $i += 2) {
             $sym = $tuple[$i];

--- a/src/php/Analyzer/TupleSymbol/PhpAGetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAGetSymbol.php
@@ -17,8 +17,8 @@ final class PhpAGetSymbol implements TupleSymbolAnalyzer
     {
         return new PhpArrayGetNode(
             $env,
-            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CTX_EXPR)),
-            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CTX_EXPR)),
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
             $tuple->getStartLocation()
         );
     }

--- a/src/php/Analyzer/TupleSymbol/PhpAPushSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAPushSymbol.php
@@ -17,8 +17,8 @@ final class PhpAPushSymbol implements TupleSymbolAnalyzer
     {
         return new PhpArrayPushNode(
             $env,
-            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CTX_EXPR)),
-            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CTX_EXPR)),
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
             $tuple->getStartLocation()
         );
     }

--- a/src/php/Analyzer/TupleSymbol/PhpASetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpASetSymbol.php
@@ -17,9 +17,9 @@ final class PhpASetSymbol implements TupleSymbolAnalyzer
     {
         return new PhpArraySetNode(
             $env,
-            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CTX_EXPR)),
-            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CTX_EXPR)),
-            $this->analyzer->analyze($tuple[3], $env->withContext(NodeEnvironment::CTX_EXPR)),
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($tuple[3], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
             $tuple->getStartLocation()
         );
     }

--- a/src/php/Analyzer/TupleSymbol/PhpAUnsetSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpAUnsetSymbol.php
@@ -16,14 +16,14 @@ final class PhpAUnsetSymbol implements TupleSymbolAnalyzer
 
     public function analyze(Tuple $tuple, NodeEnvironment $env): PhpArrayUnsetNode
     {
-        if ($env->getContext() !== NodeEnvironment::CTX_STMT) {
+        if ($env->getContext() !== NodeEnvironment::CONTEXT_STATEMENT) {
             throw AnalyzerException::withLocation("'php/unset can only be called as Statement and not as Expression", $tuple);
         }
 
         return new PhpArrayUnsetNode(
             $env,
-            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CTX_EXPR)),
-            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CTX_EXPR)),
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
             $tuple->getStartLocation()
         );
     }

--- a/src/php/Analyzer/TupleSymbol/PhpNewSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpNewSymbol.php
@@ -23,13 +23,13 @@ final class PhpNewSymbol implements TupleSymbolAnalyzer
 
         $classExpr = $this->analyzer->analyze(
             $tuple[1],
-            $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()
+            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
         );
         $args = [];
         for ($i = 2; $i < $tupleCount; $i++) {
             $args[] = $this->analyzer->analyze(
                 $tuple[$i],
-                $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
             );
         }
 

--- a/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
@@ -41,7 +41,7 @@ final class PhpObjectCallSymbol implements TupleSymbolAnalyzer
 
         $targetExpr = $this->analyzer->analyze(
             $tuple[1],
-            $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()
+            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
         );
 
         if ($tuple[2] instanceof Tuple) {
@@ -71,7 +71,7 @@ final class PhpObjectCallSymbol implements TupleSymbolAnalyzer
         for ($i = 1; $i < $tCount; $i++) {
             $args[] = $this->analyzer->analyze(
                 $tuple2[$i],
-                $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
             );
         }
 

--- a/src/php/Analyzer/TupleSymbol/RecurSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/RecurSymbol.php
@@ -59,7 +59,7 @@ final class RecurSymbol implements TupleSymbolAnalyzer
         for ($i = 1, $tupleCount = count($tuple); $i < $tupleCount; $i++) {
             $expressions[] = $this->analyzer->analyze(
                 $tuple[$i],
-                $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
             );
         }
 

--- a/src/php/Analyzer/TupleSymbol/ThrowSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ThrowSymbol.php
@@ -22,7 +22,7 @@ final class ThrowSymbol implements TupleSymbolAnalyzer
 
         return new ThrowNode(
             $env,
-            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CTX_EXPR)->withDisallowRecurFrame()),
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()),
             $tuple->getStartLocation()
         );
     }

--- a/src/php/Analyzer/TupleSymbol/TrySymbol.php
+++ b/src/php/Analyzer/TupleSymbol/TrySymbol.php
@@ -64,11 +64,11 @@ final class TrySymbol implements TupleSymbolAnalyzer
             $finally = $finally->update(0, Symbol::create(Symbol::NAME_DO));
             $finally = $this->analyzer->analyze(
                 $finally,
-                $env->withContext(NodeEnvironment::CTX_STMT)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironment::CONTEXT_STATEMENT)->withDisallowRecurFrame()
             );
         }
 
-        $catchCtx = $env->getContext() === NodeEnvironment::CTX_EXPR ? NodeEnvironment::CTX_RET : $env->getContext();
+        $catchCtx = $env->getContext() === NodeEnvironment::CONTEXT_EXPRESSION ? NodeEnvironment::CONTEXT_RETURN : $env->getContext();
         $catchNodes = [];
         /** @var Tuple $catch */
         foreach ($catches as $catch) {

--- a/src/php/Compiler/EvalCompiler.php
+++ b/src/php/Compiler/EvalCompiler.php
@@ -56,7 +56,7 @@ final class EvalCompiler
         try {
             $node = $this->analyzer->analyze(
                 $readerResult->getAst(),
-                NodeEnvironment::empty()->withContext(NodeEnvironment::CTX_RET)
+                NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_RETURN)
             );
 
             $code = $this->emitter->emitNodeAsString($node);

--- a/src/php/Emitter/OutputEmitter.php
+++ b/src/php/Emitter/OutputEmitter.php
@@ -160,14 +160,14 @@ final class OutputEmitter
 
     public function emitContextPrefix(NodeEnvironment $env, ?SourceLocation $sl = null): void
     {
-        if ($env->getContext() === NodeEnvironment::CTX_RET) {
+        if ($env->getContext() === NodeEnvironment::CONTEXT_RETURN) {
             $this->emitStr('return ', $sl);
         }
     }
 
     public function emitContextSuffix(NodeEnvironment $env, ?SourceLocation $sl = null): void
     {
-        if ($env->getContext() !== NodeEnvironment::CTX_EXPR) {
+        if ($env->getContext() !== NodeEnvironment::CONTEXT_EXPRESSION) {
             $this->emitStr(';', $sl);
         }
     }

--- a/src/php/Emitter/OutputEmitter/NodeEmitter/DoEmitter.php
+++ b/src/php/Emitter/OutputEmitter/NodeEmitter/DoEmitter.php
@@ -17,7 +17,7 @@ final class DoEmitter implements NodeEmitter
     {
         assert($node instanceof DoNode);
 
-        $wrapFn = count($node->getStmts()) > 0 && $node->getEnv()->getContext() === NodeEnvironment::CTX_EXPR;
+        $wrapFn = count($node->getStmts()) > 0 && $node->getEnv()->getContext() === NodeEnvironment::CONTEXT_EXPRESSION;
         if ($wrapFn) {
             $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
         }

--- a/src/php/Emitter/OutputEmitter/NodeEmitter/ForeachEmitter.php
+++ b/src/php/Emitter/OutputEmitter/NodeEmitter/ForeachEmitter.php
@@ -17,7 +17,7 @@ final class ForeachEmitter implements NodeEmitter
     {
         assert($node instanceof ForeachNode);
 
-        if ($node->getEnv()->getContext() !== NodeEnvironment::CTX_STMT) {
+        if ($node->getEnv()->getContext() !== NodeEnvironment::CONTEXT_STATEMENT) {
             $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
             $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
         }
@@ -37,7 +37,7 @@ final class ForeachEmitter implements NodeEmitter
         $this->outputEmitter->emitLine();
         $this->outputEmitter->emitStr('}', $node->getStartSourceLocation());
 
-        if ($node->getEnv()->getContext() !== NodeEnvironment::CTX_STMT) {
+        if ($node->getEnv()->getContext() !== NodeEnvironment::CONTEXT_STATEMENT) {
             $this->outputEmitter->emitLine();
             $this->outputEmitter->emitStr('return null;', $node->getStartSourceLocation());
             $this->outputEmitter->emitFnWrapSuffix($node->getStartSourceLocation());

--- a/src/php/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
+++ b/src/php/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
@@ -17,7 +17,7 @@ final class IfEmitter implements NodeEmitter
     {
         assert($node instanceof IfNode);
 
-        if ($node->getEnv()->getContext() === NodeEnvironment::CTX_EXPR) {
+        if ($node->getEnv()->getContext() === NodeEnvironment::CONTEXT_EXPRESSION) {
             $this->outputEmitter->emitStr('((\Phel\Lang\Truthy::isTruthy(', $node->getStartSourceLocation());
             $this->outputEmitter->emitNode($node->getTestExpr());
             $this->outputEmitter->emitStr(')) ? ', $node->getStartSourceLocation());

--- a/src/php/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php
+++ b/src/php/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php
@@ -17,7 +17,7 @@ final class LetEmitter implements NodeEmitter
     {
         assert($node instanceof LetNode);
 
-        $wrapFn = $node->getEnv()->getContext() === NodeEnvironment::CTX_EXPR;
+        $wrapFn = $node->getEnv()->getContext() === NodeEnvironment::CONTEXT_EXPRESSION;
         if ($wrapFn) {
             $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
         }

--- a/src/php/Emitter/OutputEmitter/NodeEmitter/LiteralEmitter.php
+++ b/src/php/Emitter/OutputEmitter/NodeEmitter/LiteralEmitter.php
@@ -17,7 +17,7 @@ final class LiteralEmitter implements NodeEmitter
     {
         assert($node instanceof LiteralNode);
 
-        if (!($node->getEnv()->getContext() === NodeEnvironment::CTX_STMT)) {
+        if (!($node->getEnv()->getContext() === NodeEnvironment::CONTEXT_STATEMENT)) {
             $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
             $this->outputEmitter->emitLiteral($node->getValue());
             $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());

--- a/src/php/Emitter/OutputEmitter/NodeEmitter/ThrowEmitter.php
+++ b/src/php/Emitter/OutputEmitter/NodeEmitter/ThrowEmitter.php
@@ -17,7 +17,7 @@ final class ThrowEmitter implements NodeEmitter
     {
         assert($node instanceof ThrowNode);
 
-        if ($node->getEnv()->getContext() === NodeEnvironment::CTX_EXPR) {
+        if ($node->getEnv()->getContext() === NodeEnvironment::CONTEXT_EXPRESSION) {
             $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
         }
 
@@ -25,7 +25,7 @@ final class ThrowEmitter implements NodeEmitter
         $this->outputEmitter->emitNode($node->getExceptionExpr());
         $this->outputEmitter->emitStr(';', $node->getStartSourceLocation());
 
-        if ($node->getEnv()->getContext() === NodeEnvironment::CTX_EXPR) {
+        if ($node->getEnv()->getContext() === NodeEnvironment::CONTEXT_EXPRESSION) {
             $this->outputEmitter->emitFnWrapSuffix($node->getStartSourceLocation());
         }
     }

--- a/src/php/Emitter/OutputEmitter/NodeEmitter/TryEmitter.php
+++ b/src/php/Emitter/OutputEmitter/NodeEmitter/TryEmitter.php
@@ -18,7 +18,7 @@ final class TryEmitter implements NodeEmitter
         assert($node instanceof TryNode);
 
         if ($node->getFinally() || count($node->getCatches()) > 0) {
-            if ($node->getEnv()->getContext() === NodeEnvironment::CTX_EXPR) {
+            if ($node->getEnv()->getContext() === NodeEnvironment::CONTEXT_EXPRESSION) {
                 $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
             }
 
@@ -37,7 +37,7 @@ final class TryEmitter implements NodeEmitter
                 $this->emitFinally($node->getFinally());
             }
 
-            if ($node->getEnv()->getContext() === NodeEnvironment::CTX_EXPR) {
+            if ($node->getEnv()->getContext() === NodeEnvironment::CONTEXT_EXPRESSION) {
                 $this->outputEmitter->emitFnWrapSuffix($node->getStartSourceLocation());
             }
         } else {

--- a/src/php/NodeEnvironment.php
+++ b/src/php/NodeEnvironment.php
@@ -8,7 +8,7 @@ use Phel\Lang\Symbol;
 
 final class NodeEnvironment
 {
-    public const CONTEXT_EXPRESSION = 'expresssion';
+    public const CONTEXT_EXPRESSION = 'expression';
     public const CONTEXT_STATEMENT = 'statement';
     public const CONTEXT_RETURN = 'return';
 

--- a/src/php/NodeEnvironment.php
+++ b/src/php/NodeEnvironment.php
@@ -8,12 +8,13 @@ use Phel\Lang\Symbol;
 
 final class NodeEnvironment
 {
-    public const CONTEXT_EXPRESSION = 'expr';
-    public const CONTEXT_STATEMENT = 'stmt';
-    public const CONTEXT_RETURN = 'ret';
+    public const CONTEXT_EXPRESSION = 'expresssion';
+    public const CONTEXT_STATEMENT = 'statement';
+    public const CONTEXT_RETURN = 'return';
 
     /**
      * A list of local symbols
+     *
      * @var Symbol[]
      */
     private array $locals;
@@ -25,12 +26,14 @@ final class NodeEnvironment
 
     /**
      * A mapping of local variables to shadowed names
+     *
      * @var Symbol[]
      */
     private array $shadowed;
 
     /**
      * A list of RecurFrame
+     *
      * @var array<RecurFrame|null>
      */
     private array $recurFrames;

--- a/src/php/NodeEnvironment.php
+++ b/src/php/NodeEnvironment.php
@@ -8,9 +8,9 @@ use Phel\Lang\Symbol;
 
 final class NodeEnvironment
 {
-    public const CTX_EXPR = 'expr';
-    public const CTX_STMT = 'stmt';
-    public const CTX_RET = 'ret';
+    public const CONTEXT_EXPRESSION = 'expr';
+    public const CONTEXT_STATEMENT = 'stmt';
+    public const CONTEXT_RETURN = 'ret';
 
     /**
      * A list of local symbols
@@ -68,7 +68,7 @@ final class NodeEnvironment
 
     public static function empty(): NodeEnvironment
     {
-        return new NodeEnvironment([], self::CTX_STMT, [], []);
+        return new NodeEnvironment([], self::CONTEXT_STATEMENT, [], []);
     }
 
     /**

--- a/tests/php/Unit/Analyzer/AnalyzeTupleTest.php
+++ b/tests/php/Unit/Analyzer/AnalyzeTupleTest.php
@@ -153,7 +153,7 @@ final class AnalyzeTupleTest extends TestCase
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_RECUR), 1);
         $recurFrames = [new RecurFrame([Symbol::create(Symbol::NAME_FOREACH)])];
-        $nodeEnv = new NodeEnvironment([], NodeEnvironment::CTX_STMT, [], $recurFrames);
+        $nodeEnv = new NodeEnvironment([], NodeEnvironment::CONTEXT_STATEMENT, [], $recurFrames);
         self::assertInstanceOf(RecurNode::class, $this->tupleAnalyzer->analyze($tuple, $nodeEnv));
     }
 

--- a/tests/php/Unit/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
+++ b/tests/php/Unit/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
@@ -30,10 +30,10 @@ final class ApplyEmitterTest extends TestCase
     {
         $node = new PhpVarNode(NodeEnvironment::empty(), '+');
         $args = [
-            new TupleNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CTX_EXPR), [
-                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CTX_EXPR), 2),
-                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CTX_EXPR), 3),
-                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CTX_EXPR), 4),
+            new TupleNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), [
+                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), 2),
+                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), 3),
+                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), 4),
             ]),
         ];
 
@@ -49,9 +49,9 @@ final class ApplyEmitterTest extends TestCase
     {
         $node = new PhpVarNode(NodeEnvironment::empty(), 'str');
         $args = [
-            new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CTX_EXPR), 'abc'),
-            new TupleNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CTX_EXPR), [
-                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CTX_EXPR), 'def'),
+            new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), 'abc'),
+            new TupleNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), [
+                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), 'def'),
             ]),
         ];
 
@@ -66,15 +66,15 @@ final class ApplyEmitterTest extends TestCase
         $fnNode = new FnNode(
             NodeEnvironment::empty(),
             [Symbol::create('x')],
-            new PhpVarNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CTX_RET), 'x'),
+            new PhpVarNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_RETURN), 'x'),
             [],
             $isVariadic = true,
             $recurs = false
         );
 
         $args = [
-            new TupleNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CTX_EXPR), [
-                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CTX_EXPR), 1),
+            new TupleNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), [
+                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), 1),
             ]),
         ];
 


### PR DESCRIPTION
# Description

From my point of view, it is better to have long but pronounceable nouns than abbreviations. :zipper_mouth_face: 

# Changes

- Replace `CTX_STMT` by `CONTEXT_STATEMENT`
- Replace `CTX_EXP` by `CONTEXT_EXPRESSION`
- Replace `CTX_RET` by `CONTEXt_RETURN`