### PR TITLE
Refactor Lang folder

### DIFF
--- a/src/php/Lang/AbstractType.php
+++ b/src/php/Lang/AbstractType.php
@@ -17,7 +17,7 @@ abstract class AbstractType implements IMeta, ISourceLocation
     /**
      * Check if $other is equals to $this.
      *
-     * @param mixed $other The other value.
+     * @param mixed $other The other value
      */
     abstract public function equals($other): bool;
 }

--- a/src/php/Lang/ICdr.php
+++ b/src/php/Lang/ICdr.php
@@ -1,15 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 interface ICdr
 {
-
     /**
-     * Return the sequence without the first element. If the sequence is empty
-     * returns null.
-     *
-     * @return ICdr
+     * Return the sequence without the first element. If the sequence is empty returns null.
      */
     public function cdr(): ?ICdr;
 }

--- a/src/php/Lang/IConcat.php
+++ b/src/php/Lang/IConcat.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 interface IConcat
@@ -8,8 +10,6 @@ interface IConcat
      * Concatenates a value to the data structure.
      *
      * @param mixed $xs The value to concatenate
-     *
-     * @return IConcat
      */
     public function concat($xs): IConcat;
 }

--- a/src/php/Lang/ICons.php
+++ b/src/php/Lang/ICons.php
@@ -1,16 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 interface ICons
 {
-
     /**
      * Appends a value to the front of a data structure.
      *
      * @param mixed $x The value to cons
-     *
-     * @return ICons
      */
     public function cons($x): ICons;
 }

--- a/src/php/Lang/IFirst.php
+++ b/src/php/Lang/IFirst.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 interface IFirst
 {
-
     /**
-     * Returns the first value
+     * Returns the first value.
      *
      * @return mixed|null
      */

--- a/src/php/Lang/IFn.php
+++ b/src/php/Lang/IFn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 interface IFn

--- a/src/php/Lang/IIdentical.php
+++ b/src/php/Lang/IIdentical.php
@@ -1,16 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 interface IIdentical
 {
-
     /**
      * Checks if $other is identical to $this.
      *
-     * @param mixed $other The value to compare.
-     *
-     * @return bool
+     * @param mixed $other The value to compare
      */
     public function identical($other): bool;
 }

--- a/src/php/Lang/IMeta.php
+++ b/src/php/Lang/IMeta.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 interface IMeta

--- a/src/php/Lang/IPop.php
+++ b/src/php/Lang/IPop.php
@@ -1,13 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 interface IPop
 {
-
     /**
-     * Removes the value at the beginning of a sequence and return this removed
-     * value.
+     * Removes the value at the beginning of a sequence and return this removed value.
      *
      * @return mixed
      */

--- a/src/php/Lang/IPush.php
+++ b/src/php/Lang/IPush.php
@@ -1,16 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 interface IPush
 {
-
     /**
      * Pushes a new value of the data structure.
      *
-     * @param mixed $x The new value.
-     *
-     * @return IPush
+     * @param mixed $x The new value
      */
     public function push($x): IPush;
 }

--- a/src/php/Lang/IRemove.php
+++ b/src/php/Lang/IRemove.php
@@ -1,17 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 interface IRemove
 {
-
     /**
      * Remove values on a indexed data structures.
      *
      * @param int $offset The offset where to start to remove values
-     * @param ?int $length The number of how many elements should be removed.
-     *
-     * @return IRemove
+     * @param ?int $length The number of how many elements should be removed
      */
-    public function remove(int $offest, ?int $length = null): IRemove;
+    public function remove(int $offset, ?int $length = null): IRemove;
 }

--- a/src/php/Lang/IRest.php
+++ b/src/php/Lang/IRest.php
@@ -1,15 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 interface IRest
 {
-
     /**
-     * Return the sequence without the first element. If the sequence is empty
-     * returns an empty sequence.
-     *
-     * @return IRest
+     * Return the sequence without the first element. If the sequence is empty returns an empty sequence.
      */
     public function rest(): IRest;
 }

--- a/src/php/Lang/ISeq.php
+++ b/src/php/Lang/ISeq.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 interface ISeq extends IFirst, ICdr, IRest

--- a/src/php/Lang/ISlice.php
+++ b/src/php/Lang/ISlice.php
@@ -1,17 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 interface ISlice
 {
-
     /**
      * Remove values on a indexed data structures.
      *
      * @param int $offset The offset where to start to remove values
-     * @param ?int $length The number of how many elements should be removed.
-     *
-     * @return ISlice
+     * @param ?int $length The number of how many elements should be removed
      */
     public function slice(int $offset = 0, ?int $length = null): ISlice;
 }

--- a/src/php/Lang/ISourceLocation.php
+++ b/src/php/Lang/ISourceLocation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 interface ISourceLocation

--- a/src/php/Lang/Keyword.php
+++ b/src/php/Lang/Keyword.php
@@ -20,11 +20,7 @@ final class Keyword extends AbstractType implements IIdentical, IFn
      */
     public function __invoke(Table $obj, $default = null)
     {
-        if (isset($obj[$this])) {
-            return $obj[$this];
-        }
-
-        return $default;
+        return $obj[$this] ?? $default;
     }
 
     public function getName(): string

--- a/src/php/Lang/PhelArray.php
+++ b/src/php/Lang/PhelArray.php
@@ -10,7 +10,17 @@ use InvalidArgumentException;
 use Iterator;
 use Phel\Printer;
 
-final class PhelArray extends AbstractType implements ArrayAccess, Countable, Iterator, ICons, ISlice, ISeq, IPop, IRemove, IPush, IConcat
+final class PhelArray extends AbstractType implements
+    ArrayAccess,
+    Countable,
+    Iterator,
+    ICons,
+    ISlice,
+    ISeq,
+    IPop,
+    IRemove,
+    IPush,
+    IConcat
 {
     private array $data;
 
@@ -23,18 +33,16 @@ final class PhelArray extends AbstractType implements ArrayAccess, Countable, It
     }
 
     /**
-     * Create a new Phel array from a list of value
+     * Create a new Phel array from a list of value.
      *
-     * @param mixed[] $values Thes values
-     *
-     * @return PhelArray
+     * @param mixed[] $values The values
      */
     public static function create(...$values): PhelArray
     {
         return new PhelArray($values);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if ($offset < 0) {
             throw new InvalidArgumentException('Offset must be bigger or equal zero. Given: ' . $offset);
@@ -51,12 +59,12 @@ final class PhelArray extends AbstractType implements ArrayAccess, Countable, It
         }
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->data[$offset]);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         if ($offset < 0 || $offset >= count($this->data)) {
             throw new InvalidArgumentException('Index out of bounds: ' . $offset . ' [0,' . count($this->data) . ')');

--- a/src/php/Lang/Set.php
+++ b/src/php/Lang/Set.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phel\Lang;
 
 use Countable;
@@ -8,15 +10,10 @@ use Phel\Printer;
 
 class Set extends AbstractType implements Countable, Iterator, ISeq, ICons, IPush, IConcat
 {
+    /** @var mixed[] */
+    protected array $data = [];
 
     /**
-     * @var mixed[]
-     */
-    protected $data = [];
-
-    /**
-     * Constructor
-     *
      * @param mixed[] $data A list of all values
      */
     public function __construct(array $data)
@@ -45,7 +42,7 @@ class Set extends AbstractType implements Countable, Iterator, ISeq, ICons, IPus
         return current($this->data);
     }
 
-    public function next()
+    public function next(): void
     {
         next($this->data);
     }
@@ -55,12 +52,12 @@ class Set extends AbstractType implements Countable, Iterator, ISeq, ICons, IPus
         return key($this->data);
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return key($this->data) !== null;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->data);
     }
@@ -73,7 +70,7 @@ class Set extends AbstractType implements Countable, Iterator, ISeq, ICons, IPus
 
     public function first()
     {
-        if (count($this->data) == 0) {
+        if (empty($this->data)) {
             return null;
         }
 
@@ -138,9 +135,7 @@ class Set extends AbstractType implements Countable, Iterator, ISeq, ICons, IPus
     /**
      * Creates a hash for the given key.
      *
-     * @param mixed $offset The access key of the Set.
-     *
-     * @return string
+     * @param mixed $offset The access key of the Set
      */
     private function offsetHash($offset): string
     {

--- a/src/php/Lang/SourceLocation.php
+++ b/src/php/Lang/SourceLocation.php
@@ -17,19 +17,14 @@ final class SourceLocation
         $this->column = $column;
     }
 
-    public function setFile(string $file): void
-    {
-        $this->file = $file;
-    }
-
     public function getFile(): string
     {
         return $this->file;
     }
 
-    public function setLine(int $line): void
+    public function setFile(string $file): void
     {
-        $this->line = $line;
+        $this->file = $file;
     }
 
     public function getLine(): int
@@ -37,13 +32,18 @@ final class SourceLocation
         return $this->line;
     }
 
-    public function setColumn(int $column): void
+    public function setLine(int $line): void
     {
-        $this->column = $column;
+        $this->line = $line;
     }
 
     public function getColumn(): int
     {
         return $this->column;
+    }
+
+    public function setColumn(int $column): void
+    {
+        $this->column = $column;
     }
 }

--- a/src/php/Lang/Struct.php
+++ b/src/php/Lang/Struct.php
@@ -16,25 +16,6 @@ abstract class Struct extends Table
      */
     abstract public function getAllowedKeys(): array;
 
-    /**
-     * Asserts if the offset is a valid value
-     *
-     * @param AbstractType|scalar|null $offset The offset value
-     *
-     * @return void
-     * @throws InvalidArgumentException
-     */
-    protected function validateOffset($offset): void
-    {
-        if (!in_array($offset, $this->getAllowedKeys(), false)) {
-            $keyName = Printer::nonReadable()->print($offset);
-            $structName = static::class;
-            throw new InvalidArgumentException(
-                "This key '$keyName' is not allowed for struct $structName"
-            );
-        }
-    }
-
     public function offsetSet($offset, $value): void
     {
         $this->validateOffset($offset);
@@ -60,5 +41,23 @@ abstract class Struct extends Table
     {
         $this->validateOffset($offset);
         return parent::offsetGet($offset);
+    }
+
+    /**
+     * Asserts if the offset is a valid value.
+     *
+     * @param AbstractType|scalar|null $offset The offset value
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function validateOffset($offset): void
+    {
+        if (!in_array($offset, $this->getAllowedKeys(), false)) {
+            $keyName = Printer::nonReadable()->print($offset);
+            $structName = static::class;
+            throw new InvalidArgumentException(
+                "This key '$keyName' is not allowed for struct $structName"
+            );
+        }
     }
 }

--- a/src/php/Lang/Symbol.php
+++ b/src/php/Lang/Symbol.php
@@ -91,7 +91,7 @@ final class Symbol extends AbstractType implements IIdentical
 
     public static function gen(string $prefix = '__phel_'): Symbol
     {
-        return Symbol::create($prefix . (self::$symGenCounter++));
+        return self::create($prefix . (self::$symGenCounter++));
     }
 
     public static function resetGen(): void
@@ -106,7 +106,7 @@ final class Symbol extends AbstractType implements IIdentical
 
     public function equals($other): bool
     {
-        return $other instanceof Symbol
+        return $other instanceof self
             && $this->name === $other->getName()
             && $this->namespace === $other->getNamespace();
     }

--- a/src/php/Lang/TSourceLocation.php
+++ b/src/php/Lang/TSourceLocation.php
@@ -36,7 +36,7 @@ trait TSourceLocation
      *
      * @return static
      */
-    public function copyLocationFrom($other)
+    public function copyLocationFrom($other): self
     {
         if ($other && $other instanceof ISourceLocation) {
             $this->setStartLocation($other->getStartLocation());

--- a/src/php/Lang/Table.php
+++ b/src/php/Lang/Table.php
@@ -24,9 +24,7 @@ class Table extends AbstractType implements ArrayAccess, Countable, Iterator, IS
     /**
      * Create a Table from a list of key-value pairs.
      *
-     * @param mixed[] $kvs The key-value pairs.
-     *
-     * @return Table
+     * @param mixed[] $kvs The key-value pairs
      */
     public static function fromKVs(...$kvs): Table
     {
@@ -190,9 +188,7 @@ class Table extends AbstractType implements ArrayAccess, Countable, Iterator, IS
     /**
      * Creates a hash for the given key.
      *
-     * @param mixed $offset The access key of the Table.
-     *
-     * @return string
+     * @param mixed $offset The access key of the Table
      */
     private function offsetHash($offset): string
     {

--- a/src/php/Lang/Truthy.php
+++ b/src/php/Lang/Truthy.php
@@ -7,7 +7,7 @@ namespace Phel\Lang;
 final class Truthy
 {
     /**
-     * Check if the given value evalutaes to true
+     * Check if the given value evaluates to true
      *
      * @param mixed $value The value
      */

--- a/src/php/Lang/Tuple.php
+++ b/src/php/Lang/Tuple.php
@@ -10,7 +10,15 @@ use InvalidArgumentException;
 use Iterator;
 use Phel\Printer;
 
-final class Tuple extends AbstractType implements ArrayAccess, Countable, Iterator, ISlice, ICons, ISeq, IPush, IConcat
+final class Tuple extends AbstractType implements
+    ArrayAccess,
+    Countable,
+    Iterator,
+    ISlice,
+    ICons,
+    ISeq,
+    IPush,
+    IConcat
 {
     private array $data;
     private bool $usingBracket;
@@ -45,17 +53,17 @@ final class Tuple extends AbstractType implements ArrayAccess, Countable, Iterat
         return new Tuple($values, true);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         throw new \InvalidArgumentException('Calling offsetSet is not supported on Tuples since they are immutable');
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->data[$offset]);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new \InvalidArgumentException('Calling offsetUnset is not supported on Tuples since they are immutable');
     }
@@ -68,7 +76,7 @@ final class Tuple extends AbstractType implements ArrayAccess, Countable, Iterat
         return $this->data[$offset] ?? null;
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->data);
     }
@@ -88,17 +96,17 @@ final class Tuple extends AbstractType implements ArrayAccess, Countable, Iterat
         return key($this->data);
     }
 
-    public function next()
+    public function next(): void
     {
         next($this->data);
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->data);
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return key($this->data) !== null;
     }
@@ -106,7 +114,7 @@ final class Tuple extends AbstractType implements ArrayAccess, Countable, Iterat
     /**
      * Update a tuple value. For internal use only.
      *
-     * @param int $index The index to update
+     * @param int $offset The index to update
      * @param mixed $value The value to set on $index
      *
      * @return Tuple A copy of the tuple with an update value


### PR DESCRIPTION
# Description

Small changes on `src/php/Lang/*`.

# Changes

- Add `declare(strict_types=1)` to some classes.
- Remove the comment tag `@return` when it is explicitly in the code.
- Fix small typos like `$offest` to `$offset` or some return values from some methods.
- `Lang/Keyword` replace `if` clause by a coalesce operator.
- Split imports when the line is too long ([PSR-12](https://www.php-fig.org/psr/psr-12/#41-extends-and-implements)).
- Replace the call to the class itself by `self::` keyboard.
- Other minor changes.

# Extra

I have updated some PhpDocs with a final dot when it was a comment but without it when it was a `@param` tag.
Looking at the `php cs fixer` I found this rule: [`phpdoc_annotation_without_dot`](https://mlocati.github.io/php-cs-fixer-configurator/#version:2.16|fixer:phpdoc_annotation_without_dot).
I think we should follow a unique standard and for me, this one fits good (apparently there isn't a rule as final dot only on comments but no on @param tag). :thinking: 

Also, take a look at this rule too: [phpdoc_add_missing_param_annotation](https://mlocati.github.io/php-cs-fixer-configurator/#version:2.16|fixer:phpdoc_add_missing_param_annotation)
Maybe I could create a new `issue` when we can discuss those and other `cs fixer` rules. :smile: 

What do you think @Chemaclass & @jenshaase?
