### PR TITLE
Refactoring FnSymbol again 

### DIFF
--- a/src/php/Analyzer/TupleSymbol/FnSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/FnSymbol.php
@@ -22,7 +22,7 @@ final class FnSymbol implements TupleSymbolAnalyzer
     {
         $this->verifyArguments($tuple);
 
-        $fnSymbolTuple = $this->buildFnSymbolTuple($tuple);
+        $fnSymbolTuple = FnSymbolTuple::createWithTuple($tuple);
         $recurFrame = new RecurFrame($fnSymbolTuple->params());
 
         return new FnNode(
@@ -45,22 +45,6 @@ final class FnSymbol implements TupleSymbolAnalyzer
         if (!($tuple[1] instanceof Tuple)) {
             throw AnalyzerException::withLocation("Second argument of 'fn must be a Tuple", $tuple);
         }
-    }
-
-    private function buildFnSymbolTuple(Tuple $tuple): FnSymbolTuple
-    {
-        /** @var Tuple $params */
-        $params = $tuple[1];
-        $fnSymbolTuple = new FnSymbolTuple($tuple);
-
-        foreach ($params as $param) {
-            $fnSymbolTuple->buildParamsByState($param);
-        }
-
-        $fnSymbolTuple->addDummyVariadicSymbol();
-        $fnSymbolTuple->checkAllVariablesStartWithALetterOrUnderscore();
-
-        return $fnSymbolTuple;
     }
 
     private function analyzeBody(FnSymbolTuple $fnSymbolTuple, RecurFrame $recurFrame, NodeEnvironment $env): Node

--- a/src/php/Analyzer/TupleSymbol/FnSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/FnSymbol.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Analyzer\TupleSymbol;
 
+use Phel\Analyzer\TupleSymbol\ReadModel\FnSymbolTuple;
 use Phel\Analyzer\WithAnalyzer;
 use Phel\Ast\FnNode;
 use Phel\Ast\Node;
@@ -21,27 +22,22 @@ final class FnSymbol implements TupleSymbolAnalyzer
     private const STATE_REST = 'rest';
     private const STATE_DONE = 'done';
 
-    private array $params = [];
-    private array $lets = [];
-    private bool $isVariadic = false;
-    private bool $hasVariadicForm = false;
-    private string $buildParamsState = self::STATE_START;
-
     public function analyze(Tuple $tuple, NodeEnvironment $env): FnNode
     {
         $this->verifyArguments($tuple);
-        $this->buildParams($tuple);
-        $this->addDummyVariadicSymbol();
-        $this->checkAllVariablesStartWithALetterOrUnderscore($tuple);
 
-        $recurFrame = new RecurFrame($this->params);
+        $fnSymbolTuple = $this->buildFnSymbolTuple($tuple);
+        $fnSymbolTuple->addDummyVariadicSymbol();
+        $fnSymbolTuple->checkAllVariablesStartWithALetterOrUnderscore($tuple);
+
+        $recurFrame = new RecurFrame($fnSymbolTuple->params);
 
         return new FnNode(
             $env,
-            $this->params,
-            $this->analyzeBody($tuple, $recurFrame, $env),
-            $this->buildUsesFromEnv($env),
-            $this->isVariadic,
+            $fnSymbolTuple->params,
+            $this->analyzeBody($fnSymbolTuple, $recurFrame, $env),
+            $this->buildUsesFromEnv($env, $fnSymbolTuple),
+            $fnSymbolTuple->isVariadic,
             $recurFrame->isActive(),
             $tuple->getStartLocation()
         );
@@ -58,116 +54,38 @@ final class FnSymbol implements TupleSymbolAnalyzer
         }
     }
 
-    private function buildParams(Tuple $tuple): void
+    private function buildFnSymbolTuple(Tuple $tuple): FnSymbolTuple
     {
-        $this->resetParamsAndLetsState();
         /** @var Tuple $params */
         $params = $tuple[1];
+        $fnSymbolTuple = new FnSymbolTuple($tuple);
 
         foreach ($params as $param) {
-            switch ($this->buildParamsState) {
+            switch ($fnSymbolTuple->buildParamsState) {
                 case self::STATE_START:
-                    $this->buildParamsStart($param);
+                    $fnSymbolTuple->buildParamsStart($param);
                     break;
                 case self::STATE_REST:
-                    $this->buildParamsRest($tuple, $param);
+                    $fnSymbolTuple->buildParamsRest($tuple, $param);
                     break;
                 case self::STATE_DONE:
-                    $this->buildParamsDone($tuple);
+                    $fnSymbolTuple->buildParamsDone($tuple);
             }
         }
+
+        return $fnSymbolTuple;
     }
 
-    private function resetParamsAndLetsState(): void
+    private function analyzeBody(FnSymbolTuple $fnSymbolTuple, RecurFrame $recurFrame, NodeEnvironment $env): Node
     {
-        $this->params = [];
-        $this->lets = [];
-        $this->isVariadic = false;
-        $this->hasVariadicForm = false;
-        $this->buildParamsState = self::STATE_START;
-    }
+        $tupleBody = array_slice($fnSymbolTuple->parentTuple->toArray(), 2);
 
-    /** @param mixed $param */
-    private function buildParamsStart($param): void
-    {
-        if ($param instanceof Symbol) {
-            if ($this->isSymWithName($param, '&')) {
-                $this->isVariadic = true;
-                $this->buildParamsState = self::STATE_REST;
-            } elseif ($param->getName() === '_') {
-                $this->params[] = Symbol::gen()->copyLocationFrom($param);
-            } else {
-                $this->params[] = $param;
-            }
-        } else {
-            $tempSym = Symbol::gen()->copyLocationFrom($param);
-            $this->params[] = $tempSym;
-            $this->lets[] = $param;
-            $this->lets[] = $tempSym;
-        }
-    }
-
-    /** @param mixed $x */
-    private function isSymWithName($x, string $name): bool
-    {
-        return $x instanceof Symbol && $x->getName() === $name;
-    }
-
-    /** @param mixed $param */
-    private function buildParamsRest(Tuple $tuple, $param): void
-    {
-        $this->buildParamsState = self::STATE_DONE;
-        $this->hasVariadicForm = true;
-
-        if ($this->isSymWithName($param, '_')) {
-            $this->params[] = Symbol::gen()->copyLocationFrom($param);
-        } elseif ($param instanceof Symbol) {
-            $this->params[] = $param;
-        } else {
-            $tempSym = Symbol::gen()->copyLocationFrom($tuple);
-            $this->params[] = $tempSym;
-            $this->lets[] = $param;
-            $this->lets[] = $tempSym;
-        }
-    }
-
-    private function buildParamsDone(Tuple $tuple): void
-    {
-        throw AnalyzerException::withLocation(
-            'Unsupported parameter form, only one symbol can follow the & parameter',
-            $tuple
-        );
-    }
-
-    private function addDummyVariadicSymbol(): void
-    {
-        if ($this->isVariadic && !$this->hasVariadicForm) {
-            $this->params[] = Symbol::gen();
-        }
-    }
-
-    private function checkAllVariablesStartWithALetterOrUnderscore(Tuple $tuple): void
-    {
-        foreach ($this->params as $param) {
-            if (!preg_match("/^[a-zA-Z_\x80-\xff].*$/", $param->getName())) {
-                throw AnalyzerException::withLocation(
-                    "Variable names must start with a letter or underscore: {$param->getName()}",
-                    $tuple
-                );
-            }
-        }
-    }
-
-    private function analyzeBody(Tuple $tuple, RecurFrame $recurFrame, NodeEnvironment $env): Node
-    {
-        $tupleBody = array_slice($tuple->toArray(), 2);
-
-        $body = empty($this->lets)
+        $body = empty($fnSymbolTuple->lets)
             ? $this->createDoTupleWithBody($tupleBody)
-            : $this->createLetTupleWithBody($tupleBody);
+            : $this->createLetTupleWithBody($fnSymbolTuple, $tupleBody);
 
         $bodyEnv = $env
-            ->withMergedLocals($this->params)
+            ->withMergedLocals($fnSymbolTuple->params)
             ->withContext(NodeEnvironment::CTX_RET)
             ->withAddedRecurFrame($recurFrame);
 
@@ -182,17 +100,17 @@ final class FnSymbol implements TupleSymbolAnalyzer
         )->copyLocationFrom($body);
     }
 
-    private function createLetTupleWithBody(array $tupleBody): Tuple
+    private function createLetTupleWithBody(FnSymbolTuple $fnSymbolTuple, array $tupleBody): Tuple
     {
         return Tuple::create(
             (Symbol::create(Symbol::NAME_LET))->copyLocationFrom($tupleBody),
-            (new Tuple($this->lets, true))->copyLocationFrom($tupleBody),
+            (new Tuple($fnSymbolTuple->lets, true))->copyLocationFrom($tupleBody),
             ...$tupleBody
         )->copyLocationFrom($tupleBody);
     }
 
-    private function buildUsesFromEnv(NodeEnvironment $env): array
+    private function buildUsesFromEnv(NodeEnvironment $env, FnSymbolTuple $fnSymbolTuple): array
     {
-        return array_diff($env->getLocals(), $this->params);
+        return array_diff($env->getLocals(), $fnSymbolTuple->params);
     }
 }

--- a/src/php/Analyzer/TupleSymbol/ReadModel/FnSymbolTuple.php
+++ b/src/php/Analyzer/TupleSymbol/ReadModel/FnSymbolTuple.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Analyzer\TupleSymbol\ReadModel;
+
+use Phel\Exceptions\AnalyzerException;
+use Phel\Lang\Symbol;
+use Phel\Lang\Tuple;
+
+final class FnSymbolTuple
+{
+    private const STATE_START = 'start';
+    private const STATE_REST = 'rest';
+    private const STATE_DONE = 'done';
+
+    public Tuple $parentTuple;
+
+    public array $params = [];
+    public array $lets = [];
+    public bool $isVariadic = false;
+    public bool $hasVariadicForm = false;
+    public string $buildParamsState = self::STATE_START;
+
+
+    public function __construct(Tuple $parentTuple)
+    {
+        $this->parentTuple = $parentTuple;
+    }
+
+    public function addDummyVariadicSymbol(): void
+    {
+        if ($this->isVariadic && !$this->hasVariadicForm) {
+            $this->params[] = Symbol::gen();
+        }
+    }
+
+    public function checkAllVariablesStartWithALetterOrUnderscore(Tuple $tuple): void
+    {
+        foreach ($this->params as $param) {
+            if (!preg_match("/^[a-zA-Z_\x80-\xff].*$/", $param->getName())) {
+                throw AnalyzerException::withLocation(
+                    "Variable names must start with a letter or underscore: {$param->getName()}",
+                    $tuple
+                );
+            }
+        }
+    }
+
+    /** @param mixed $param */
+    public function buildParamsStart($param): void
+    {
+        if ($param instanceof Symbol) {
+            if ($this->isSymWithName($param, '&')) {
+                $this->isVariadic = true;
+                $this->buildParamsState = self::STATE_REST;
+            } elseif ($param->getName() === '_') {
+                $this->params[] = Symbol::gen()->copyLocationFrom($param);
+            } else {
+                $this->params[] = $param;
+            }
+        } else {
+            $tempSym = Symbol::gen()->copyLocationFrom($param);
+            $this->params[] = $tempSym;
+            $this->lets[] = $param;
+            $this->lets[] = $tempSym;
+        }
+    }
+
+    /** @param mixed $x */
+    private function isSymWithName($x, string $name): bool
+    {
+        return $x instanceof Symbol && $x->getName() === $name;
+    }
+
+    /** @param mixed $param */
+    public function buildParamsRest(Tuple $tuple, $param): void
+    {
+        $this->buildParamsState = self::STATE_DONE;
+        $this->hasVariadicForm = true;
+
+        if ($this->isSymWithName($param, '_')) {
+            $this->params[] = Symbol::gen()->copyLocationFrom($param);
+        } elseif ($param instanceof Symbol) {
+            $this->params[] = $param;
+        } else {
+            $tempSym = Symbol::gen()->copyLocationFrom($tuple);
+            $this->params[] = $tempSym;
+            $this->lets[] = $param;
+            $this->lets[] = $tempSym;
+        }
+    }
+
+    public function buildParamsDone(Tuple $tuple): void
+    {
+        throw AnalyzerException::withLocation(
+            'Unsupported parameter form, only one symbol can follow the & parameter',
+            $tuple
+        );
+    }
+}

--- a/src/php/Analyzer/TupleSymbol/ReadModel/FnSymbolTuple.php
+++ b/src/php/Analyzer/TupleSymbol/ReadModel/FnSymbolTuple.php
@@ -13,19 +13,42 @@ final class FnSymbolTuple
     private const STATE_START = 'start';
     private const STATE_REST = 'rest';
     private const STATE_DONE = 'done';
+    private const PARENT_TUPLE_BODY_OFFSET = 2;
 
     public Tuple $parentTuple;
 
-    public array $params = [];
-    public array $lets = [];
-    public bool $isVariadic = false;
-    public bool $hasVariadicForm = false;
-    public string $buildParamsState = self::STATE_START;
-
+    private array $params = [];
+    private array $lets = [];
+    private bool $isVariadic = false;
+    private bool $hasVariadicForm = false;
+    private string $buildParamsState = self::STATE_START;
 
     public function __construct(Tuple $parentTuple)
     {
         $this->parentTuple = $parentTuple;
+    }
+
+    public function params(): array
+    {
+        return $this->params;
+    }
+
+    public function lets(): array
+    {
+        return $this->lets;
+    }
+
+    public function isVariadic(): bool
+    {
+        return $this->isVariadic;
+    }
+
+    public function parentTupleBody(): array
+    {
+        return array_slice(
+            $this->parentTuple->toArray(),
+            self::PARENT_TUPLE_BODY_OFFSET
+        );
     }
 
     public function addDummyVariadicSymbol(): void
@@ -35,20 +58,35 @@ final class FnSymbolTuple
         }
     }
 
-    public function checkAllVariablesStartWithALetterOrUnderscore(Tuple $tuple): void
+    public function checkAllVariablesStartWithALetterOrUnderscore(): void
     {
         foreach ($this->params as $param) {
             if (!preg_match("/^[a-zA-Z_\x80-\xff].*$/", $param->getName())) {
                 throw AnalyzerException::withLocation(
                     "Variable names must start with a letter or underscore: {$param->getName()}",
-                    $tuple
+                    $this->parentTuple
                 );
             }
         }
     }
 
     /** @param mixed $param */
-    public function buildParamsStart($param): void
+    public function buildParamsByState($param): void
+    {
+        switch ($this->buildParamsState) {
+            case self::STATE_START:
+                $this->buildParamsStart($param);
+                break;
+            case self::STATE_REST:
+                $this->buildParamsRest($param);
+                break;
+            case self::STATE_DONE:
+                $this->buildParamsDone();
+        }
+    }
+
+    /** @param mixed $param */
+    private function buildParamsStart($param): void
     {
         if ($param instanceof Symbol) {
             if ($this->isSymWithName($param, '&')) {
@@ -74,7 +112,7 @@ final class FnSymbolTuple
     }
 
     /** @param mixed $param */
-    public function buildParamsRest(Tuple $tuple, $param): void
+    private function buildParamsRest($param): void
     {
         $this->buildParamsState = self::STATE_DONE;
         $this->hasVariadicForm = true;
@@ -84,18 +122,18 @@ final class FnSymbolTuple
         } elseif ($param instanceof Symbol) {
             $this->params[] = $param;
         } else {
-            $tempSym = Symbol::gen()->copyLocationFrom($tuple);
+            $tempSym = Symbol::gen()->copyLocationFrom($this->parentTuple);
             $this->params[] = $tempSym;
             $this->lets[] = $param;
             $this->lets[] = $tempSym;
         }
     }
 
-    public function buildParamsDone(Tuple $tuple): void
+    private function buildParamsDone(): void
     {
         throw AnalyzerException::withLocation(
             'Unsupported parameter form, only one symbol can follow the & parameter',
-            $tuple
+            $this->parentTuple
         );
     }
 }


### PR DESCRIPTION
# Description 📚 

I realized that I could refactor the `FnSymbol` class again, following the same principle as I did last time with `ForeachSymbol`.

The `FnSymbolTuple` can be created using the named constructor `createWithTuple()`.

# Changes ⛓️ 

- Extracted some logic from `FnSymbol` to `FnSymbolTuple` in order to improve the readability and abstraction level of those classes.