### PR TITLE
Replace scalar type by the scalar ones

### DIFF
--- a/src/php/Analyzer.php
+++ b/src/php/Analyzer.php
@@ -33,13 +33,13 @@ final class Analyzer
         return $this->globalEnvironment;
     }
 
-    /** @param AbstractType|scalar|null $x */
+    /** @param AbstractType|string|float|int|bool|null $x */
     public function analyzeInEmptyEnv($x): Node
     {
         return $this->analyze($x, NodeEnvironment::empty());
     }
 
-    /** @param AbstractType|scalar|null $x */
+    /** @param AbstractType|string|float|int|bool|null $x */
     public function analyze($x, NodeEnvironment $env): Node
     {
         if ($this->isLiteral($x)) {
@@ -69,7 +69,7 @@ final class Analyzer
         throw new AnalyzerException('Unhandled type: ' . var_export($x, true));
     }
 
-    /** @param AbstractType|scalar|null $x */
+    /** @param AbstractType|string|float|int|bool|null $x */
     private function isLiteral($x): bool
     {
         return is_string($x)

--- a/src/php/Analyzer/AnalyzeLiteral.php
+++ b/src/php/Analyzer/AnalyzeLiteral.php
@@ -10,7 +10,7 @@ use Phel\NodeEnvironment;
 
 final class AnalyzeLiteral
 {
-    /** @param AbstractType|scalar|null $value */
+    /** @param AbstractType|string|float|int|bool|null $value */
     public function analyze($value, NodeEnvironment $env): LiteralNode
     {
         $sourceLocation = ($value instanceof AbstractType)

--- a/src/php/Analyzer/TupleSymbol/ApplySymbol.php
+++ b/src/php/Analyzer/TupleSymbol/ApplySymbol.php
@@ -33,7 +33,7 @@ final class ApplySymbol implements TupleSymbolAnalyzer
     /**
      * Analyze the function expression of the apply special form.
      *
-     * @param AbstractType|scalar|null $x
+     * @param AbstractType|string|float|int|bool|null $x
      * @param NodeEnvironment $env
      *
      * @return Node

--- a/src/php/Analyzer/TupleSymbol/DefSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/DefSymbol.php
@@ -85,7 +85,7 @@ final class DefSymbol implements TupleSymbolAnalyzer
             && !is_scalar($init)
             && $init !== null
         ) {
-            throw AnalyzerException::withLocation('$init must be AbstractType|scalar|null', $tuple);
+            throw AnalyzerException::withLocation('$init must be AbstractType|string|float|int|bool|null', $tuple);
         }
 
         if (is_string($meta)) {
@@ -121,7 +121,7 @@ final class DefSymbol implements TupleSymbolAnalyzer
     }
 
     /**
-     * @param AbstractType|scalar|null $init
+     * @param AbstractType|string|float|int|bool|null $init
      */
     private function analyzeInit($init, NodeEnvironment $env, string $namespace, Symbol $nameSymbol): Node
     {

--- a/src/php/Analyzer/TupleSymbol/InvokeSymbol.php
+++ b/src/php/Analyzer/TupleSymbol/InvokeSymbol.php
@@ -46,7 +46,7 @@ final class InvokeSymbol implements TupleSymbolAnalyzer
         return $result;
     }
 
-    /** @return AbstractType|scalar|null */
+    /** @return AbstractType|string|float|int|bool|null */
     private function macroExpand(Tuple $tuple, NodeEnvironment $env)
     {
         $tupleCount = count($tuple);
@@ -82,7 +82,7 @@ final class InvokeSymbol implements TupleSymbolAnalyzer
         throw AnalyzerException::withLocation('This is not macro expandable: ' . get_class($node), $tuple);
     }
 
-    /** @param AbstractType|scalar|null $x */
+    /** @param AbstractType|string|float|int|bool|null $x */
     private function enrichLocation($x, AbstractType $parent): void
     {
         if ($x instanceof Tuple) {

--- a/src/php/Ast/LiteralNode.php
+++ b/src/php/Ast/LiteralNode.php
@@ -10,11 +10,11 @@ use Phel\NodeEnvironment;
 
 final class LiteralNode extends Node
 {
-    /** @var AbstractType|scalar|null */
+    /** @var AbstractType|string|float|int|bool|null */
     private $value;
 
     /**
-     * @param AbstractType|scalar|null $value
+     * @param AbstractType|string|float|int|bool|null $value
      */
     public function __construct(NodeEnvironment $env, $value, ?SourceLocation $sourceLocation = null)
     {
@@ -23,7 +23,7 @@ final class LiteralNode extends Node
     }
 
     /**
-     * @return AbstractType|scalar|null
+     * @return AbstractType|string|float|int|bool|null
      */
     public function getValue()
     {

--- a/src/php/Ast/QuoteNode.php
+++ b/src/php/Ast/QuoteNode.php
@@ -14,7 +14,7 @@ final class QuoteNode extends Node
     private $value;
 
     /**
-     * @param AbstractType|scalar|null $value
+     * @param AbstractType|string|float|int|bool|null $value
      */
     public function __construct(NodeEnvironment $env, $value, ?SourceLocation $sourceLocation = null)
     {

--- a/src/php/Destructure.php
+++ b/src/php/Destructure.php
@@ -68,8 +68,8 @@ final class Destructure
      * Destructure a $binding $value pair and add the result to $bindings.
      *
      * @param array $bindings A reference to already defined bindings
-     * @param AbstractType|scalar|null $binding The binding form
-     * @param AbstractType|scalar|null $value The value form
+     * @param AbstractType|string|float|int|bool|null $binding The binding form
+     * @param AbstractType|string|float|int|bool|null $value The value form
      */
     private function destructure(array &$bindings, $binding, $value): void
     {
@@ -91,7 +91,7 @@ final class Destructure
      *
      * @param array $bindings A reference to already defined bindings
      * @param Table $table The binding form
-     * @param AbstractType|scalar|null $value The value form
+     * @param AbstractType|string|float|int|bool|null $value The value form
      */
     private function processTable(array &$bindings, Table $table, $value): void
     {
@@ -116,7 +116,7 @@ final class Destructure
      *
      * @param array $bindings A reference to already defined bindings
      * @param PhelArray $phelArray The binding form
-     * @param AbstractType|scalar|null $value The value form
+     * @param AbstractType|string|float|int|bool|null $value The value form
      */
     private function processArray(array &$bindings, PhelArray $phelArray, $value): void
     {
@@ -144,7 +144,7 @@ final class Destructure
      *
      * @param array $bindings A reference to already defined bindings
      * @param Symbol $binding The binding form
-     * @param AbstractType|scalar|null $value The value form
+     * @param AbstractType|string|float|int|bool|null $value The value form
      */
     private function processSymbol(array &$bindings, Symbol $binding, $value): void
     {
@@ -161,7 +161,7 @@ final class Destructure
      *
      * @param array $bindings A reference to already defined bindings
      * @param Tuple $tuple The binding form
-     * @param AbstractType|scalar|null $value The value form
+     * @param AbstractType|string|float|int|bool|null $value The value form
      */
     private function processTuple(array &$bindings, Tuple $tuple, $value): void
     {

--- a/src/php/Emitter/OutputEmitter.php
+++ b/src/php/Emitter/OutputEmitter.php
@@ -229,11 +229,11 @@ final class OutputEmitter
     }
 
     /**
-     * @param AbstractType|scalar|null $x The value
+     * @param AbstractType|string|float|int|bool|null $value
      */
-    public function emitLiteral($x): void
+    public function emitLiteral($value): void
     {
-        (new LiteralEmitter($this))->emitLiteral($x);
+        (new LiteralEmitter($this))->emitLiteral($value);
     }
 
     public function increaseIndentLevel(): void

--- a/src/php/Emitter/OutputEmitter/LiteralEmitter.php
+++ b/src/php/Emitter/OutputEmitter/LiteralEmitter.php
@@ -24,7 +24,7 @@ final class LiteralEmitter
     }
 
     /**
-     * @param AbstractType|scalar|null $x The value
+     * @param AbstractType|string|float|int|bool|null $x The value
      */
     public function emitLiteral($x): void
     {

--- a/src/php/Lang/Keyword.php
+++ b/src/php/Lang/Keyword.php
@@ -16,7 +16,7 @@ final class Keyword extends AbstractType implements IIdentical, IFn
     }
 
     /**
-     * @param scalar|null|AbstractType $default
+     * @param AbstractType|string|float|int|bool|null $default
      */
     public function __invoke(Table $obj, $default = null)
     {

--- a/src/php/Lang/Struct.php
+++ b/src/php/Lang/Struct.php
@@ -48,7 +48,7 @@ abstract class Struct extends Table
     /**
      * Asserts if the offset is a valid value.
      *
-     * @param AbstractType|scalar|null $offset
+     * @param AbstractType|string|float|int|bool|null $offset
      *
      * @throws InvalidArgumentException
      */

--- a/src/php/Lang/Tuple.php
+++ b/src/php/Lang/Tuple.php
@@ -35,7 +35,7 @@ final class Tuple extends AbstractType implements
     /**
      * Create a new Tuple.
      *
-     * @param AbstractType|scalar|null ...$values
+     * @param AbstractType|string|float|int|bool|null ...$values
      */
     public static function create(...$values): Tuple
     {
@@ -45,7 +45,7 @@ final class Tuple extends AbstractType implements
     /**
      * Create a new bracket Tuple.
      *
-     * @param AbstractType|scalar|null ...$values
+     * @param AbstractType|string|float|int|bool|null ...$values
      */
     public static function createBracket(...$values): Tuple
     {

--- a/src/php/Quasiquote.php
+++ b/src/php/Quasiquote.php
@@ -22,9 +22,9 @@ final class Quasiquote
     }
 
     /**
-     * @param AbstractType|scalar|null $form The form to quasiqoute
+     * @param AbstractType|string|float|int|bool|null $form The form to quasiqoute
      *
-     * @return AbstractType|scalar|null
+     * @return AbstractType|string|float|int|bool|null
      */
     public function transform($form)
     {
@@ -57,7 +57,7 @@ final class Quasiquote
     }
 
     /**
-     * @param AbstractType|scalar|null $form
+     * @param AbstractType|string|float|int|bool|null $form
      */
     private function isUnquote($form): bool
     {
@@ -65,7 +65,7 @@ final class Quasiquote
     }
 
     /**
-     * @param AbstractType|scalar|null $form
+     * @param AbstractType|string|float|int|bool|null $form
      */
     private function isUnquoteSplicing($form): bool
     {
@@ -135,7 +135,7 @@ final class Quasiquote
     }
 
     /**
-     * @param AbstractType|scalar|null $x The form to check
+     * @param AbstractType|string|float|int|bool|null $x The form to check
      */
     private function isLiteral($x): bool
     {
@@ -148,7 +148,7 @@ final class Quasiquote
     }
 
     /**
-     * @param AbstractType|scalar|null $form
+     * @param AbstractType|string|float|int|bool|null $form
      */
     private function createTupleOtherwise($form): Tuple
     {

--- a/src/php/Reader.php
+++ b/src/php/Reader.php
@@ -86,7 +86,7 @@ final class Reader
     }
 
     /**
-     * @return AbstractType|null|scalar
+     * @return AbstractType|string|float|int|bool|null
      */
     public function readExpression(Generator $tokenStream)
     {
@@ -198,7 +198,7 @@ final class Reader
     }
 
     /**
-     * @return AbstractType|scalar|null
+     * @return AbstractType|string|float|int|bool|null
      */
     private function readQuasiquote(Generator $tokenStream)
     {
@@ -218,7 +218,7 @@ final class Reader
     }
 
     /**
-     * @return AbstractType|scalar
+     * @return AbstractType|string|float|int|bool
      */
     private function readMeta(Generator $tokenStream)
     {
@@ -266,7 +266,7 @@ final class Reader
     }
 
     /**
-     * @return AbstractType|scalar
+     * @return AbstractType|string|float|int|bool
      */
     private function readExpressionHard(Generator $tokenStream, string $errorMessage)
     {

--- a/src/php/ReaderResult.php
+++ b/src/php/ReaderResult.php
@@ -6,19 +6,12 @@ use Phel\Lang\AbstractType;
 
 class ReaderResult
 {
-
-    /**
-     * @var AbstractType|scalar|null
-     */
+    /** @var AbstractType|string|float|int|bool|null */
     private $ast;
+    private CodeSnippet $codeSnippet;
 
     /**
-     * @var CodeSnippet
-     */
-    private $codeSnippet;
-
-    /**
-     * @param AbstractType|scalar|null $ast The form read by the reader
+     * @param AbstractType|string|float|int|bool|null $ast The form read by the reader
      * @param CodeSnippet $codeSnippet The Code that have been read for the form
      */
     public function __construct($ast, CodeSnippet $codeSnippet)
@@ -28,7 +21,7 @@ class ReaderResult
     }
 
     /**
-     * @return AbstractType|scalar|null
+     * @return AbstractType|string|float|int|bool|null
      */
     public function getAst()
     {

--- a/tests/php/Unit/ReaderTest.php
+++ b/tests/php/Unit/ReaderTest.php
@@ -574,7 +574,7 @@ final class ReaderTest extends TestCase
         );
     }
 
-    /** @return AbstractType|scalar|null */
+    /** @return AbstractType|string|float|int|bool|null */
     public function read($string, bool $removeLoc = false)
     {
         Symbol::resetGen();
@@ -605,7 +605,7 @@ final class ReaderTest extends TestCase
         return $x;
     }
 
-    /** @param AbstractType|scalar|null $x */
+    /** @param AbstractType|string|float|int|bool|null $x */
     private function removeLoc($x)
     {
         if ($x instanceof AbstractType) {


### PR DESCRIPTION
# 🔗 Description

Replace `scalar` keyword from Phpdocs by the scalar types `(string|float|int|bool)`.

Check this [issue](https://github.com/jenshaase/phel-lang/issues/119) for more information 🐘 