### PR TITLE
Creating NodeEnvironmentInterface

### DIFF
--- a/src/php/Compiler/Analyzer.php
+++ b/src/php/Compiler/Analyzer.php
@@ -28,7 +28,7 @@ final class Analyzer implements AnalyzerInterface
         $this->globalEnvironment = $globalEnvironment;
     }
 
-    public function resolve(Symbol $name, NodeEnvironment $env): ?Node
+    public function resolve(Symbol $name, NodeEnvironmentInterface $env): ?Node
     {
         return $this->globalEnvironment->resolve($name, $env);
     }
@@ -71,7 +71,7 @@ final class Analyzer implements AnalyzerInterface
     /**
      * @param AbstractType|string|float|int|bool|null $x
      */
-    public function analyzeMacro($x, NodeEnvironment $env): Node
+    public function analyzeMacro($x, NodeEnvironmentInterface $env): Node
     {
         $this->globalEnvironment->setAllowPrivateAccess(true);
         $result = $this->analyze($x, $env);
@@ -83,7 +83,7 @@ final class Analyzer implements AnalyzerInterface
     /**
      * @param AbstractType|string|float|int|bool|null $x
      */
-    public function analyze($x, NodeEnvironment $env): Node
+    public function analyze($x, NodeEnvironmentInterface $env): Node
     {
         if ($this->isLiteral($x)) {
             return (new AnalyzeLiteral())->analyze($x, $env);

--- a/src/php/Compiler/Analyzer/AnalyzeArray.php
+++ b/src/php/Compiler/Analyzer/AnalyzeArray.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Phel\Compiler\Analyzer;
 
 use Phel\Compiler\Ast\ArrayNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\PhelArray;
 
 final class AnalyzeArray
 {
     use WithAnalyzer;
 
-    public function analyze(PhelArray $array, NodeEnvironment $env): ArrayNode
+    public function analyze(PhelArray $array, NodeEnvironmentInterface $env): ArrayNode
     {
         $values = [];
-        $valueEnv = $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION);
+        $valueEnv = $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION);
 
         foreach ($array as $value) {
             $values[] = $this->analyzer->analyze($value, $valueEnv);

--- a/src/php/Compiler/Analyzer/AnalyzeBracketTuple.php
+++ b/src/php/Compiler/Analyzer/AnalyzeBracketTuple.php
@@ -5,19 +5,19 @@ declare(strict_types=1);
 namespace Phel\Compiler\Analyzer;
 
 use Phel\Compiler\Ast\TupleNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\Tuple;
 
 final class AnalyzeBracketTuple
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): TupleNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): TupleNode
     {
         $args = [];
 
         foreach ($tuple as $arg) {
-            $envDisallowRecur = $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame();
+            $envDisallowRecur = $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame();
             $args[] = $this->analyzer->analyze($arg, $envDisallowRecur);
         }
 

--- a/src/php/Compiler/Analyzer/AnalyzeLiteral.php
+++ b/src/php/Compiler/Analyzer/AnalyzeLiteral.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phel\Compiler\Analyzer;
 
 use Phel\Compiler\Ast\LiteralNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\AbstractType;
 
 final class AnalyzeLiteral
@@ -13,7 +13,7 @@ final class AnalyzeLiteral
     /**
      * @param AbstractType|string|float|int|bool|null $value
      */
-    public function analyze($value, NodeEnvironment $env): LiteralNode
+    public function analyze($value, NodeEnvironmentInterface $env): LiteralNode
     {
         $sourceLocation = ($value instanceof AbstractType)
             ? $value->getStartLocation()

--- a/src/php/Compiler/Analyzer/AnalyzeSymbol.php
+++ b/src/php/Compiler/Analyzer/AnalyzeSymbol.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Analyzer;
 use Phel\Compiler\Ast\LocalVarNode;
 use Phel\Compiler\Ast\Node;
 use Phel\Compiler\Ast\PhpVarNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Symbol;
 
@@ -15,7 +15,7 @@ final class AnalyzeSymbol
 {
     use WithAnalyzer;
 
-    public function analyze(Symbol $symbol, NodeEnvironment $env): Node
+    public function analyze(Symbol $symbol, NodeEnvironmentInterface $env): Node
     {
         if ($symbol->getNamespace() === 'php') {
             return new PhpVarNode($env, $symbol->getName(), $symbol->getStartLocation());
@@ -28,7 +28,7 @@ final class AnalyzeSymbol
         return $this->createGlobalResolve($symbol, $env);
     }
 
-    private function createLocalVarNode(Symbol $symbol, NodeEnvironment $env): LocalVarNode
+    private function createLocalVarNode(Symbol $symbol, NodeEnvironmentInterface $env): LocalVarNode
     {
         $shadowedVar = $env->getShadowed($symbol);
 
@@ -41,7 +41,7 @@ final class AnalyzeSymbol
         return new LocalVarNode($env, $symbol, $symbol->getStartLocation());
     }
 
-    private function createGlobalResolve(Symbol $symbol, NodeEnvironment $env): Node
+    private function createGlobalResolve(Symbol $symbol, NodeEnvironmentInterface $env): Node
     {
         $globalResolve = $this->analyzer->resolve($symbol, $env);
 

--- a/src/php/Compiler/Analyzer/AnalyzeTable.php
+++ b/src/php/Compiler/Analyzer/AnalyzeTable.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Phel\Compiler\Analyzer;
 
 use Phel\Compiler\Ast\TableNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\Table;
 
 final class AnalyzeTable
 {
     use WithAnalyzer;
 
-    public function analyze(Table $table, NodeEnvironment $env): TableNode
+    public function analyze(Table $table, NodeEnvironmentInterface $env): TableNode
     {
         $keyValues = [];
-        $kvEnv = $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION);
+        $kvEnv = $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION);
 
         foreach ($table as $key => $value) {
             $keyValues[] = $this->analyzer->analyze($key, $kvEnv);

--- a/src/php/Compiler/Analyzer/AnalyzeTuple.php
+++ b/src/php/Compiler/Analyzer/AnalyzeTuple.php
@@ -27,7 +27,7 @@ use Phel\Compiler\Analyzer\TupleSymbol\ThrowSymbol;
 use Phel\Compiler\Analyzer\TupleSymbol\TrySymbol;
 use Phel\Compiler\Analyzer\TupleSymbol\TupleSymbolAnalyzer;
 use Phel\Compiler\Ast\Node;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Exceptions\PhelCodeException;
 use Phel\Lang\Symbol;
@@ -42,7 +42,7 @@ final class AnalyzeTuple
     /**
      * @throws AnalyzerException|PhelCodeException
      */
-    public function analyze(Tuple $tuple, NodeEnvironment $env): Node
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): Node
     {
         $symbolName = $this->getSymbolName($tuple);
         $symbol = $this->createSymbolAnalyzerByName($symbolName);

--- a/src/php/Compiler/Analyzer/TupleSymbol/ApplySymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/ApplySymbol.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\ApplyNode;
 use Phel\Compiler\Ast\Node;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\AbstractType;
 use Phel\Lang\Tuple;
@@ -16,7 +16,7 @@ final class ApplySymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): ApplyNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): ApplyNode
     {
         if (count($tuple) < 3) {
             throw AnalyzerException::withLocation("At least three arguments are required for 'apply", $tuple);
@@ -34,19 +34,19 @@ final class ApplySymbol implements TupleSymbolAnalyzer
      * Analyze the function expression of the apply special form.
      *
      * @param AbstractType|string|float|int|bool|null $x
-     * @param NodeEnvironment $env
+     * @param NodeEnvironmentInterface $env
      *
      * @return Node
      */
-    private function fnExpr($x, NodeEnvironment $env): Node
+    private function fnExpr($x, NodeEnvironmentInterface $env): Node
     {
         return $this->analyzer->analyze(
             $x,
-            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
         );
     }
 
-    private function arguments(Tuple $x, NodeEnvironment $env): array
+    private function arguments(Tuple $x, NodeEnvironmentInterface $env): array
     {
         $args = [];
         for ($i = 2, $iMax = count($x); $i < $iMax; $i++) {

--- a/src/php/Compiler/Analyzer/TupleSymbol/DefStructSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/DefStructSymbol.php
@@ -6,7 +6,7 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\DefStructNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
@@ -15,7 +15,7 @@ final class DefStructSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): DefStructNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): DefStructNode
     {
         if (count($tuple) !== 3) {
             throw AnalyzerException::withLocation(

--- a/src/php/Compiler/Analyzer/TupleSymbol/DefSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/DefSymbol.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\DefNode;
 use Phel\Compiler\Ast\Node;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Exceptions\PhelCodeException;
 use Phel\Lang\AbstractType;
@@ -25,7 +25,7 @@ final class DefSymbol implements TupleSymbolAnalyzer
     /**
      * @throws PhelCodeException
      */
-    public function analyze(Tuple $tuple, NodeEnvironment $env): DefNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): DefNode
     {
         $this->ensureDefIsAllowed($tuple, $env);
         $this->verifySizeOfTuple($tuple);
@@ -51,7 +51,7 @@ final class DefSymbol implements TupleSymbolAnalyzer
         );
     }
 
-    private function ensureDefIsAllowed(Tuple $tuple, NodeEnvironment $env): void
+    private function ensureDefIsAllowed(Tuple $tuple, NodeEnvironmentInterface $env): void
     {
         if (!$env->isDefAllowed()) {
             throw AnalyzerException::withLocation("'def inside of a 'def is forbidden", $tuple);
@@ -119,11 +119,11 @@ final class DefSymbol implements TupleSymbolAnalyzer
     /**
      * @param AbstractType|string|float|int|bool|null $init
      */
-    private function analyzeInit($init, NodeEnvironment $env, string $namespace, Symbol $nameSymbol): Node
+    private function analyzeInit($init, NodeEnvironmentInterface $env, string $namespace, Symbol $nameSymbol): Node
     {
         $initEnv = $env
             ->withBoundTo($namespace . '\\' . $nameSymbol)
-            ->withContext(NodeEnvironment::CONTEXT_EXPRESSION)
+            ->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)
             ->withDisallowRecurFrame()
             ->withDefAllowed(false);
 

--- a/src/php/Compiler/Analyzer/TupleSymbol/DoSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/DoSymbol.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\DoNode;
 use Phel\Compiler\Ast\Node;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
@@ -16,7 +16,7 @@ final class DoSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): DoNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): DoNode
     {
         if (!($tuple[0] instanceof Symbol && $tuple[0]->getName() === Symbol::NAME_DO)) {
             throw AnalyzerException::withLocation("This is not a 'do.", $tuple);
@@ -27,7 +27,7 @@ final class DoSymbol implements TupleSymbolAnalyzer
         for ($i = 1; $i < $tupleCount - 1; $i++) {
             $stmts[] = $this->analyzer->analyze(
                 $tuple[$i],
-                $env->withContext(NodeEnvironment::CONTEXT_STATEMENT)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironmentInterface::CONTEXT_STATEMENT)->withDisallowRecurFrame()
             );
         }
 
@@ -39,14 +39,14 @@ final class DoSymbol implements TupleSymbolAnalyzer
         );
     }
 
-    private function ret(Tuple $tuple, NodeEnvironment $env): Node
+    private function ret(Tuple $tuple, NodeEnvironmentInterface $env): Node
     {
         $tupleCount = count($tuple);
 
         if ($tupleCount > 2) {
-            $retEnv = $env->getContext() === NodeEnvironment::CONTEXT_STATEMENT
-                ? $env->withContext(NodeEnvironment::CONTEXT_STATEMENT)
-                : $env->withContext(NodeEnvironment::CONTEXT_RETURN);
+            $retEnv = $env->getContext() === NodeEnvironmentInterface::CONTEXT_STATEMENT
+                ? $env->withContext(NodeEnvironmentInterface::CONTEXT_STATEMENT)
+                : $env->withContext(NodeEnvironmentInterface::CONTEXT_RETURN);
 
             return $this->analyzer->analyze($tuple[$tupleCount - 1], $retEnv);
         }

--- a/src/php/Compiler/Analyzer/TupleSymbol/FnSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/FnSymbol.php
@@ -8,7 +8,7 @@ use Phel\Compiler\Analyzer\TupleSymbol\ReadModel\FnSymbolTuple;
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\FnNode;
 use Phel\Compiler\Ast\Node;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Compiler\RecurFrame;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Symbol;
@@ -18,7 +18,7 @@ final class FnSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): FnNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): FnNode
     {
         $this->verifyArguments($tuple);
 
@@ -47,7 +47,7 @@ final class FnSymbol implements TupleSymbolAnalyzer
         }
     }
 
-    private function analyzeBody(FnSymbolTuple $fnSymbolTuple, RecurFrame $recurFrame, NodeEnvironment $env): Node
+    private function analyzeBody(FnSymbolTuple $fnSymbolTuple, RecurFrame $recurFrame, NodeEnvironmentInterface $env): Node
     {
         $tupleBody = $fnSymbolTuple->parentTupleBody();
 
@@ -57,7 +57,7 @@ final class FnSymbol implements TupleSymbolAnalyzer
 
         $bodyEnv = $env
             ->withMergedLocals($fnSymbolTuple->params())
-            ->withContext(NodeEnvironment::CONTEXT_RETURN)
+            ->withContext(NodeEnvironmentInterface::CONTEXT_RETURN)
             ->withAddedRecurFrame($recurFrame);
 
         return $this->analyzer->analyze($body, $bodyEnv);
@@ -80,7 +80,7 @@ final class FnSymbol implements TupleSymbolAnalyzer
         )->copyLocationFrom($tupleBody);
     }
 
-    private function buildUsesFromEnv(NodeEnvironment $env, FnSymbolTuple $fnSymbolTuple): array
+    private function buildUsesFromEnv(NodeEnvironmentInterface $env, FnSymbolTuple $fnSymbolTuple): array
     {
         return array_diff($env->getLocals(), $fnSymbolTuple->params());
     }

--- a/src/php/Compiler/Analyzer/TupleSymbol/ForeachSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/ForeachSymbol.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 use Phel\Compiler\Analyzer\TupleSymbol\ReadModel\ForeachSymbolTuple;
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\ForeachNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
@@ -16,7 +16,7 @@ final class ForeachSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): ForeachNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): ForeachNode
     {
         $this->verifyArguments($tuple);
 
@@ -26,7 +26,7 @@ final class ForeachSymbol implements TupleSymbolAnalyzer
 
         $bodyExpr = $this->analyzer->analyze(
             $this->buildTupleBody($foreachSymbolTuple->lets(), $tuple),
-            $foreachSymbolTuple->bodyEnv()->withContext(NodeEnvironment::CONTEXT_STATEMENT)
+            $foreachSymbolTuple->bodyEnv()->withContext(NodeEnvironmentInterface::CONTEXT_STATEMENT)
         );
 
         return new ForeachNode(
@@ -56,7 +56,7 @@ final class ForeachSymbol implements TupleSymbolAnalyzer
         }
     }
 
-    private function buildForeachSymbolTuple(Tuple $foreachTuple, NodeEnvironment $env): ForeachSymbolTuple
+    private function buildForeachSymbolTuple(Tuple $foreachTuple, NodeEnvironmentInterface $env): ForeachSymbolTuple
     {
         if (count($foreachTuple) === 2) {
             return $this->buildForeachTupleWhen2Args($foreachTuple, $env);
@@ -65,7 +65,7 @@ final class ForeachSymbol implements TupleSymbolAnalyzer
         return $this->buildForeachTupleWhen3Args($foreachTuple, $env);
     }
 
-    private function buildForeachTupleWhen2Args(Tuple $foreachTuple, NodeEnvironment $env): ForeachSymbolTuple
+    private function buildForeachTupleWhen2Args(Tuple $foreachTuple, NodeEnvironmentInterface $env): ForeachSymbolTuple
     {
         $lets = [];
         $valueSymbol = $foreachTuple[0];
@@ -79,13 +79,13 @@ final class ForeachSymbol implements TupleSymbolAnalyzer
         $bodyEnv = $env->withMergedLocals([$valueSymbol]);
         $listExpr = $this->analyzer->analyze(
             $foreachTuple[1],
-            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)
+            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)
         );
 
         return new ForeachSymbolTuple($lets, $bodyEnv, $listExpr, $valueSymbol);
     }
 
-    private function buildForeachTupleWhen3Args(Tuple $foreachTuple, NodeEnvironment $env): ForeachSymbolTuple
+    private function buildForeachTupleWhen3Args(Tuple $foreachTuple, NodeEnvironmentInterface $env): ForeachSymbolTuple
     {
         $lets = [];
         [$keySymbol, $valueSymbol] = $foreachTuple;
@@ -107,7 +107,7 @@ final class ForeachSymbol implements TupleSymbolAnalyzer
         $bodyEnv = $env->withMergedLocals([$valueSymbol, $keySymbol]);
         $listExpr = $this->analyzer->analyze(
             $foreachTuple[2],
-            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)
+            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)
         );
 
         return new ForeachSymbolTuple($lets, $bodyEnv, $listExpr, $valueSymbol, $keySymbol);

--- a/src/php/Compiler/Analyzer/TupleSymbol/IfSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/IfSymbol.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\IfNode;
 use Phel\Compiler\Ast\Node;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 
@@ -18,7 +18,7 @@ final class IfSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): IfNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): IfNode
     {
         $this->verifyArguments($tuple);
 
@@ -40,21 +40,21 @@ final class IfSymbol implements TupleSymbolAnalyzer
         }
     }
 
-    private function testExpression(Tuple $tuple, NodeEnvironment $env): Node
+    private function testExpression(Tuple $tuple, NodeEnvironmentInterface $env): Node
     {
         $envWithDisallowRecurFrame = $env
-            ->withContext(NodeEnvironment::CONTEXT_EXPRESSION)
+            ->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)
             ->withDisallowRecurFrame();
 
         return $this->analyzer->analyze($tuple[1], $envWithDisallowRecurFrame);
     }
 
-    private function thenExpression(Tuple $tuple, NodeEnvironment $env): Node
+    private function thenExpression(Tuple $tuple, NodeEnvironmentInterface $env): Node
     {
         return $this->analyzer->analyze($tuple[2], $env);
     }
 
-    private function elseExpression(Tuple $tuple, NodeEnvironment $env): Node
+    private function elseExpression(Tuple $tuple, NodeEnvironmentInterface $env): Node
     {
         if (count($tuple) === 3) {
             return $this->analyzer->analyze(null, $env);

--- a/src/php/Compiler/Analyzer/TupleSymbol/InvokeSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/InvokeSymbol.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\CallNode;
 use Phel\Compiler\Ast\GlobalVarNode;
 use Phel\Compiler\Ast\Node;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\AbstractType;
 use Phel\Lang\Tuple;
@@ -18,11 +18,11 @@ final class InvokeSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): Node
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): Node
     {
         $f = $this->analyzer->analyze(
             $tuple[0],
-            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
         );
 
         if ($f instanceof GlobalVarNode && $f->isMacro()) {
@@ -37,7 +37,7 @@ final class InvokeSymbol implements TupleSymbolAnalyzer
         );
     }
 
-    private function globalMacro(Tuple $tuple, NodeEnvironment $env): Node
+    private function globalMacro(Tuple $tuple, NodeEnvironmentInterface $env): Node
     {
         return $this->analyzer->analyzeMacro($this->macroExpand($tuple, $env), $env);
     }
@@ -45,7 +45,7 @@ final class InvokeSymbol implements TupleSymbolAnalyzer
     /**
      * @return AbstractType|string|float|int|bool|null
      */
-    private function macroExpand(Tuple $tuple, NodeEnvironment $env)
+    private function macroExpand(Tuple $tuple, NodeEnvironmentInterface $env)
     {
         $tupleCount = count($tuple);
         /** @psalm-suppress PossiblyNullArgument */
@@ -112,13 +112,13 @@ final class InvokeSymbol implements TupleSymbolAnalyzer
         }
     }
 
-    private function arguments(Tuple $tuple, NodeEnvironment $env): array
+    private function arguments(Tuple $tuple, NodeEnvironmentInterface $env): array
     {
         $arguments = [];
         for ($i = 1, $iMax = count($tuple); $i < $iMax; $i++) {
             $arguments[] = $this->analyzer->analyze(
                 $tuple[$i],
-                $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
             );
         }
 

--- a/src/php/Compiler/Analyzer/TupleSymbol/LetSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/LetSymbol.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\BindingNode;
 use Phel\Compiler\Ast\LetNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Destructure;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Symbol;
@@ -17,7 +17,7 @@ final class LetSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): LetNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): LetNode
     {
         if (count($tuple) < 2) {
             throw AnalyzerException::withLocation("At least two arguments are required for 'let", $tuple);
@@ -44,7 +44,7 @@ final class LetSymbol implements TupleSymbolAnalyzer
         return $this->analyzeLetOrLoop($newTuple, $env);
     }
 
-    private function analyzeLetOrLoop(Tuple $tuple, NodeEnvironment $env): LetNode
+    private function analyzeLetOrLoop(Tuple $tuple, NodeEnvironmentInterface $env): LetNode
     {
         $exprs = [];
         for ($i = 2, $iMax = count($tuple); $i < $iMax; $i++) {
@@ -62,8 +62,8 @@ final class LetSymbol implements TupleSymbolAnalyzer
         $bodyEnv = $env
             ->withMergedLocals($locals)
             ->withContext(
-                $env->getContext() === NodeEnvironment::CONTEXT_EXPRESSION
-                    ? NodeEnvironment::CONTEXT_RETURN
+                $env->getContext() === NodeEnvironmentInterface::CONTEXT_EXPRESSION
+                    ? NodeEnvironmentInterface::CONTEXT_RETURN
                     : $env->getContext()
             );
 
@@ -85,10 +85,10 @@ final class LetSymbol implements TupleSymbolAnalyzer
     /**
      * @return BindingNode[]
      */
-    private function analyzeBindings(Tuple $tuple, NodeEnvironment $env): array
+    private function analyzeBindings(Tuple $tuple, NodeEnvironmentInterface $env): array
     {
         $tupleCount = count($tuple);
-        $initEnv = $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame();
+        $initEnv = $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame();
         $nodes = [];
         for ($i = 0; $i < $tupleCount; $i += 2) {
             $sym = $tuple[$i];

--- a/src/php/Compiler/Analyzer/TupleSymbol/LoopSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/LoopSymbol.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\BindingNode;
 use Phel\Compiler\Ast\LetNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Compiler\RecurFrame;
 use Phel\Destructure;
 use Phel\Exceptions\AnalyzerException;
@@ -18,7 +18,7 @@ final class LoopSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): LetNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): LetNode
     {
         $tupleCount = count($tuple);
         if (!($tuple[0] instanceof Symbol && $tuple[0]->getName() === Symbol::NAME_LOOP)) {
@@ -75,7 +75,7 @@ final class LoopSymbol implements TupleSymbolAnalyzer
         return $this->analyzeLetOrLoop($tuple, $env);
     }
 
-    private function analyzeLetOrLoop(Tuple $tuple, NodeEnvironment $env): LetNode
+    private function analyzeLetOrLoop(Tuple $tuple, NodeEnvironmentInterface $env): LetNode
     {
         $tupleCount = count($tuple);
         $exprs = [];
@@ -96,8 +96,8 @@ final class LoopSymbol implements TupleSymbolAnalyzer
         $bodyEnv = $env
             ->withMergedLocals($locals)
             ->withContext(
-                $env->getContext() === NodeEnvironment::CONTEXT_EXPRESSION
-                    ? NodeEnvironment::CONTEXT_RETURN
+                $env->getContext() === NodeEnvironmentInterface::CONTEXT_EXPRESSION
+                    ? NodeEnvironmentInterface::CONTEXT_RETURN
                     : $env->getContext()
             );
 
@@ -121,10 +121,10 @@ final class LoopSymbol implements TupleSymbolAnalyzer
     /**
      * @return BindingNode[]
      */
-    private function analyzeBindings(Tuple $tuple, NodeEnvironment $env): array
+    private function analyzeBindings(Tuple $tuple, NodeEnvironmentInterface $env): array
     {
         $tupleCount = count($tuple);
-        $initEnv = $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame();
+        $initEnv = $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame();
         $nodes = [];
         for ($i = 0; $i < $tupleCount; $i += 2) {
             $sym = $tuple[$i];

--- a/src/php/Compiler/Analyzer/TupleSymbol/NsSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/NsSymbol.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 use Phel\Compiler\Analyzer\PhpKeywords;
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\NsNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
@@ -18,7 +18,7 @@ final class NsSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): NsNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): NsNode
     {
         $tupleCount = count($tuple);
         if (!($tuple[1] instanceof Symbol)) {

--- a/src/php/Compiler/Analyzer/TupleSymbol/PhpAGetSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/PhpAGetSymbol.php
@@ -6,19 +6,19 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\PhpArrayGetNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\Tuple;
 
 final class PhpAGetSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): PhpArrayGetNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): PhpArrayGetNode
     {
         return new PhpArrayGetNode(
             $env,
-            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
-            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
             $tuple->getStartLocation()
         );
     }

--- a/src/php/Compiler/Analyzer/TupleSymbol/PhpAPushSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/PhpAPushSymbol.php
@@ -6,19 +6,19 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\PhpArrayPushNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\Tuple;
 
 final class PhpAPushSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): PhpArrayPushNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): PhpArrayPushNode
     {
         return new PhpArrayPushNode(
             $env,
-            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
-            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
             $tuple->getStartLocation()
         );
     }

--- a/src/php/Compiler/Analyzer/TupleSymbol/PhpASetSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/PhpASetSymbol.php
@@ -6,20 +6,20 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\PhpArraySetNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\Tuple;
 
 final class PhpASetSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): PhpArraySetNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): PhpArraySetNode
     {
         return new PhpArraySetNode(
             $env,
-            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
-            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
-            $this->analyzer->analyze($tuple[3], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($tuple[3], $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
             $tuple->getStartLocation()
         );
     }

--- a/src/php/Compiler/Analyzer/TupleSymbol/PhpAUnsetSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/PhpAUnsetSymbol.php
@@ -6,7 +6,7 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\PhpArrayUnsetNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 
@@ -14,16 +14,16 @@ final class PhpAUnsetSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): PhpArrayUnsetNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): PhpArrayUnsetNode
     {
-        if ($env->getContext() !== NodeEnvironment::CONTEXT_STATEMENT) {
+        if ($env->getContext() !== NodeEnvironmentInterface::CONTEXT_STATEMENT) {
             throw AnalyzerException::withLocation("'php/unset can only be called as Statement and not as Expression", $tuple);
         }
 
         return new PhpArrayUnsetNode(
             $env,
-            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
-            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
+            $this->analyzer->analyze($tuple[2], $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)),
             $tuple->getStartLocation()
         );
     }

--- a/src/php/Compiler/Analyzer/TupleSymbol/PhpNewSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/PhpNewSymbol.php
@@ -6,7 +6,7 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\PhpNewNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 
@@ -14,7 +14,7 @@ final class PhpNewSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): PhpNewNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): PhpNewNode
     {
         $tupleCount = count($tuple);
         if ($tupleCount < 2) {
@@ -23,13 +23,13 @@ final class PhpNewSymbol implements TupleSymbolAnalyzer
 
         $classExpr = $this->analyzer->analyze(
             $tuple[1],
-            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
         );
         $args = [];
         for ($i = 2; $i < $tupleCount; $i++) {
             $args[] = $this->analyzer->analyze(
                 $tuple[$i],
-                $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
             );
         }
 

--- a/src/php/Compiler/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/PhpObjectCallSymbol.php
@@ -8,7 +8,7 @@ use Phel\Compiler\AnalyzerInterface;
 use Phel\Compiler\Ast\MethodCallNode;
 use Phel\Compiler\Ast\PhpObjectCallNode;
 use Phel\Compiler\Ast\PropertyOrConstantAccessNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
@@ -25,7 +25,7 @@ final class PhpObjectCallSymbol implements TupleSymbolAnalyzer
         $this->isStatic = $isStatic;
     }
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): PhpObjectCallNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): PhpObjectCallNode
     {
         $fnName = $this->isStatic
             ? Symbol::NAME_PHP_OBJECT_STATIC_CALL
@@ -41,7 +41,7 @@ final class PhpObjectCallSymbol implements TupleSymbolAnalyzer
 
         $targetExpr = $this->analyzer->analyze(
             $tuple[1],
-            $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+            $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
         );
 
         if ($tuple[2] instanceof Tuple) {
@@ -62,7 +62,7 @@ final class PhpObjectCallSymbol implements TupleSymbolAnalyzer
         );
     }
 
-    private function callExprForMethodCall(NodeEnvironment $env, Tuple $tuple): MethodCallNode
+    private function callExprForMethodCall(NodeEnvironmentInterface $env, Tuple $tuple): MethodCallNode
     {
         /** @var Tuple $tuple2 */
         $tuple2 = $tuple[2];
@@ -71,7 +71,7 @@ final class PhpObjectCallSymbol implements TupleSymbolAnalyzer
         for ($i = 1; $i < $tCount; $i++) {
             $args[] = $this->analyzer->analyze(
                 $tuple2[$i],
-                $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
             );
         }
 
@@ -79,7 +79,7 @@ final class PhpObjectCallSymbol implements TupleSymbolAnalyzer
         return new MethodCallNode($env, $tuple2[0], $args, $tuple2->getStartLocation());
     }
 
-    private function callExprForPropertyCall(NodeEnvironment $env, Tuple $tuple): PropertyOrConstantAccessNode
+    private function callExprForPropertyCall(NodeEnvironmentInterface $env, Tuple $tuple): PropertyOrConstantAccessNode
     {
         /** @var Symbol $tuple2 */
         $tuple2 = $tuple[2];

--- a/src/php/Compiler/Analyzer/TupleSymbol/QuoteSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/QuoteSymbol.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Phel\Compiler\Analyzer\TupleSymbol;
 
 use Phel\Compiler\Ast\QuoteNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
 
 final class QuoteSymbol implements TupleSymbolAnalyzer
 {
-    public function analyze(Tuple $tuple, NodeEnvironment $env): QuoteNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): QuoteNode
     {
         if (!($tuple[0] instanceof Symbol && $tuple[0]->getName() === Symbol::NAME_QUOTE)) {
             throw AnalyzerException::withLocation("This is not a 'quote.", $tuple);

--- a/src/php/Compiler/Analyzer/TupleSymbol/ReadModel/ForeachSymbolTuple.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/ReadModel/ForeachSymbolTuple.php
@@ -5,20 +5,20 @@ declare(strict_types=1);
 namespace Phel\Compiler\Analyzer\TupleSymbol\ReadModel;
 
 use Phel\Compiler\Ast\Node;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\Symbol;
 
 final class ForeachSymbolTuple
 {
     private array $lets;
-    private NodeEnvironment $bodyEnv;
+    private NodeEnvironmentInterface $bodyEnv;
     private Node $listExpr;
     private Symbol $valueSymbol;
     private ?Symbol $keySymbol;
 
     public function __construct(
         array $lets,
-        NodeEnvironment $bodyEnv,
+        NodeEnvironmentInterface $bodyEnv,
         Node $listExpr,
         Symbol $valueSymbol,
         ?Symbol $keySymbol = null
@@ -35,7 +35,7 @@ final class ForeachSymbolTuple
         return $this->lets;
     }
 
-    public function bodyEnv(): NodeEnvironment
+    public function bodyEnv(): NodeEnvironmentInterface
     {
         return $this->bodyEnv;
     }

--- a/src/php/Compiler/Analyzer/TupleSymbol/RecurSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/RecurSymbol.php
@@ -6,7 +6,7 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\RecurNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
@@ -15,7 +15,7 @@ final class RecurSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): RecurNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): RecurNode
     {
         if (!$this->isValidRecurTuple($tuple)) {
             throw AnalyzerException::withLocation("This is not a 'recur.", $tuple);
@@ -52,14 +52,14 @@ final class RecurSymbol implements TupleSymbolAnalyzer
             && $tuple[0]->getName() === Symbol::NAME_RECUR;
     }
 
-    public function expressions(Tuple $tuple, NodeEnvironment $env): array
+    public function expressions(Tuple $tuple, NodeEnvironmentInterface $env): array
     {
         $expressions = [];
 
         for ($i = 1, $tupleCount = count($tuple); $i < $tupleCount; $i++) {
             $expressions[] = $this->analyzer->analyze(
                 $tuple[$i],
-                $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()
             );
         }
 

--- a/src/php/Compiler/Analyzer/TupleSymbol/ThrowSymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/ThrowSymbol.php
@@ -6,7 +6,7 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\ThrowNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Tuple;
 
@@ -14,7 +14,7 @@ final class ThrowSymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): ThrowNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): ThrowNode
     {
         if (count($tuple) !== 2) {
             throw AnalyzerException::withLocation("Exact one argument is required for 'throw", $tuple);
@@ -22,7 +22,7 @@ final class ThrowSymbol implements TupleSymbolAnalyzer
 
         return new ThrowNode(
             $env,
-            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironment::CONTEXT_EXPRESSION)->withDisallowRecurFrame()),
+            $this->analyzer->analyze($tuple[1], $env->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION)->withDisallowRecurFrame()),
             $tuple->getStartLocation()
         );
     }

--- a/src/php/Compiler/Analyzer/TupleSymbol/TrySymbol.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/TrySymbol.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Analyzer\TupleSymbol;
 use Phel\Compiler\Analyzer\WithAnalyzer;
 use Phel\Compiler\Ast\CatchNode;
 use Phel\Compiler\Ast\TryNode;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Exceptions\AnalyzerException;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
@@ -16,7 +16,7 @@ final class TrySymbol implements TupleSymbolAnalyzer
 {
     use WithAnalyzer;
 
-    public function analyze(Tuple $tuple, NodeEnvironment $env): TryNode
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): TryNode
     {
         $tupleCount = count($tuple);
         $state = 'start';
@@ -64,11 +64,11 @@ final class TrySymbol implements TupleSymbolAnalyzer
             $finally = $finally->update(0, Symbol::create(Symbol::NAME_DO));
             $finally = $this->analyzer->analyze(
                 $finally,
-                $env->withContext(NodeEnvironment::CONTEXT_STATEMENT)->withDisallowRecurFrame()
+                $env->withContext(NodeEnvironmentInterface::CONTEXT_STATEMENT)->withDisallowRecurFrame()
             );
         }
 
-        $catchCtx = $env->getContext() === NodeEnvironment::CONTEXT_EXPRESSION ? NodeEnvironment::CONTEXT_RETURN : $env->getContext();
+        $catchCtx = $env->getContext() === NodeEnvironmentInterface::CONTEXT_EXPRESSION ? NodeEnvironmentInterface::CONTEXT_RETURN : $env->getContext();
         $catchNodes = [];
         /** @var Tuple $catch */
         foreach ($catches as $catch) {

--- a/src/php/Compiler/Analyzer/TupleSymbol/TupleSymbolAnalyzer.php
+++ b/src/php/Compiler/Analyzer/TupleSymbol/TupleSymbolAnalyzer.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Phel\Compiler\Analyzer\TupleSymbol;
 
 use Phel\Compiler\Ast\Node;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\Tuple;
 
 interface TupleSymbolAnalyzer
 {
-    public function analyze(Tuple $tuple, NodeEnvironment $env): Node;
+    public function analyze(Tuple $tuple, NodeEnvironmentInterface $env): Node;
 }

--- a/src/php/Compiler/AnalyzerInterface.php
+++ b/src/php/Compiler/AnalyzerInterface.php
@@ -14,14 +14,14 @@ interface AnalyzerInterface
     /**
      * @param AbstractType|string|float|int|bool|null $x
      */
-    public function analyze($x, NodeEnvironment $env): Node;
+    public function analyze($x, NodeEnvironmentInterface $env): Node;
 
     /**
      * @param AbstractType|string|float|int|bool|null $x
      */
-    public function analyzeMacro($x, NodeEnvironment $env): Node;
+    public function analyzeMacro($x, NodeEnvironmentInterface $env): Node;
 
-    public function resolve(Symbol $name, NodeEnvironment $env): ?Node;
+    public function resolve(Symbol $name, NodeEnvironmentInterface $env): ?Node;
 
     public function getNamespace(): string;
 

--- a/src/php/Compiler/Ast/ApplyNode.php
+++ b/src/php/Compiler/Ast/ApplyNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class ApplyNode extends Node
@@ -18,7 +18,7 @@ final class ApplyNode extends Node
      * @param Node[] $arguments
      */
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         Node $fn,
         array $arguments,
         ?SourceLocation $sourceLocation = null

--- a/src/php/Compiler/Ast/ArrayNode.php
+++ b/src/php/Compiler/Ast/ArrayNode.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class ArrayNode extends Node
 {
     private array $values;
 
-    public function __construct(NodeEnvironment $env, array $values, ?SourceLocation $sourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, array $values, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct($env, $sourceLocation);
         $this->values = $values;

--- a/src/php/Compiler/Ast/BindingNode.php
+++ b/src/php/Compiler/Ast/BindingNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
@@ -15,7 +15,7 @@ final class BindingNode extends Node
     private Node $initExpr;
 
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         Symbol $symbol,
         Symbol $shadow,
         Node $initExpr,

--- a/src/php/Compiler/Ast/CallNode.php
+++ b/src/php/Compiler/Ast/CallNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class CallNode extends Node
@@ -17,7 +17,7 @@ final class CallNode extends Node
     /**
      * @param Node[] $arguments
      */
-    public function __construct(NodeEnvironment $env, Node $fn, $arguments, ?SourceLocation $sourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, Node $fn, $arguments, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct($env, $sourceLocation);
         $this->fn = $fn;

--- a/src/php/Compiler/Ast/CatchNode.php
+++ b/src/php/Compiler/Ast/CatchNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
@@ -15,7 +15,7 @@ final class CatchNode extends Node
     private Node $body;
 
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         Symbol $type,
         Symbol $name,
         Node $body,

--- a/src/php/Compiler/Ast/DefNode.php
+++ b/src/php/Compiler/Ast/DefNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 use Phel\Lang\Table;
@@ -17,7 +17,7 @@ final class DefNode extends Node
     private Node $init;
 
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         string $namespace,
         Symbol $name,
         Table $meta,

--- a/src/php/Compiler/Ast/DefStructNode.php
+++ b/src/php/Compiler/Ast/DefStructNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
@@ -19,7 +19,7 @@ final class DefStructNode extends Node
     private array $params;
 
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         string $namespace,
         Symbol $name,
         array $params,

--- a/src/php/Compiler/Ast/DoNode.php
+++ b/src/php/Compiler/Ast/DoNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class DoNode extends Node
@@ -17,7 +17,7 @@ final class DoNode extends Node
     /**
      * @param Node[] $stmts
      */
-    public function __construct(NodeEnvironment $env, array $stmts, Node $ret, ?SourceLocation $sourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, array $stmts, Node $ret, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct($env, $sourceLocation);
         $this->stmts = $stmts;

--- a/src/php/Compiler/Ast/FnNode.php
+++ b/src/php/Compiler/Ast/FnNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
@@ -27,7 +27,7 @@ final class FnNode extends Node
      * @param Symbol[] $uses
      */
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         array $params,
         Node $body,
         array $uses,

--- a/src/php/Compiler/Ast/ForeachNode.php
+++ b/src/php/Compiler/Ast/ForeachNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
@@ -16,7 +16,7 @@ final class ForeachNode extends Node
     private ?Symbol $keySymbol;
 
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         Node $bodyExpr,
         Node $listExpr,
         Symbol $valueSymbol,

--- a/src/php/Compiler/Ast/GlobalVarNode.php
+++ b/src/php/Compiler/Ast/GlobalVarNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
@@ -17,7 +17,7 @@ final class GlobalVarNode extends Node
     private Table $meta;
 
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         string $namespace,
         Symbol $name,
         Table $meta,

--- a/src/php/Compiler/Ast/IfNode.php
+++ b/src/php/Compiler/Ast/IfNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class IfNode extends Node
@@ -14,7 +14,7 @@ final class IfNode extends Node
     private Node $elseExpr;
 
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         Node $testExpr,
         Node $thenExpr,
         Node $elseExpr,

--- a/src/php/Compiler/Ast/LetNode.php
+++ b/src/php/Compiler/Ast/LetNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class LetNode extends Node
@@ -20,7 +20,7 @@ final class LetNode extends Node
      * @param BindingNode[] $bindings
      */
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         array $bindings,
         Node $bodyExpr,
         bool $isLoop,

--- a/src/php/Compiler/Ast/LiteralNode.php
+++ b/src/php/Compiler/Ast/LiteralNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\AbstractType;
 use Phel\Lang\SourceLocation;
 
@@ -16,7 +16,7 @@ final class LiteralNode extends Node
     /**
      * @param AbstractType|string|float|int|bool|null $value
      */
-    public function __construct(NodeEnvironment $env, $value, ?SourceLocation $sourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, $value, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct($env, $sourceLocation);
         $this->value = $value;

--- a/src/php/Compiler/Ast/LocalVarNode.php
+++ b/src/php/Compiler/Ast/LocalVarNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
@@ -12,7 +12,7 @@ final class LocalVarNode extends Node
 {
     private Symbol $name;
 
-    public function __construct(NodeEnvironment $env, Symbol $name, ?SourceLocation $sourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, Symbol $name, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct($env, $sourceLocation);
         $this->name = $name;

--- a/src/php/Compiler/Ast/MethodCallNode.php
+++ b/src/php/Compiler/Ast/MethodCallNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
@@ -16,7 +16,7 @@ final class MethodCallNode extends Node
     /**
      * @param Node[] $args
      */
-    public function __construct(NodeEnvironment $env, Symbol $fn, array $args, ?SourceLocation $sourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, Symbol $fn, array $args, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct($env, $sourceLocation);
         $this->fn = $fn;

--- a/src/php/Compiler/Ast/Node.php
+++ b/src/php/Compiler/Ast/Node.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 abstract class Node
 {
-    private NodeEnvironment $env;
+    private NodeEnvironmentInterface $env;
     private ?SourceLocation $startSourceLocation;
 
-    public function __construct(NodeEnvironment $env, ?SourceLocation $startSourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, ?SourceLocation $startSourceLocation = null)
     {
         $this->env = $env;
         $this->startSourceLocation = $startSourceLocation;
     }
 
-    public function getEnv(): NodeEnvironment
+    public function getEnv(): NodeEnvironmentInterface
     {
         return $this->env;
     }

--- a/src/php/Compiler/Ast/PhelArrayNode.php
+++ b/src/php/Compiler/Ast/PhelArrayNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class PhelArrayNode extends Node
@@ -15,7 +15,7 @@ final class PhelArrayNode extends Node
     /**
      * @param Node[] $args
      */
-    public function __construct(NodeEnvironment $env, array $args, ?SourceLocation $sourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, array $args, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct($env, $sourceLocation);
         $this->args = $args;

--- a/src/php/Compiler/Ast/PhpArrayGetNode.php
+++ b/src/php/Compiler/Ast/PhpArrayGetNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class PhpArrayGetNode extends Node
@@ -13,7 +13,7 @@ final class PhpArrayGetNode extends Node
     private Node $accessExpr;
 
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         Node $arrayExpr,
         Node $accessExpr,
         ?SourceLocation $sourceLocation = null

--- a/src/php/Compiler/Ast/PhpArrayPushNode.php
+++ b/src/php/Compiler/Ast/PhpArrayPushNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class PhpArrayPushNode extends Node
@@ -13,7 +13,7 @@ final class PhpArrayPushNode extends Node
     private Node $valueExpr;
 
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         Node $arrayExpr,
         Node $valueExpr,
         ?SourceLocation $sourceLocation = null

--- a/src/php/Compiler/Ast/PhpArraySetNode.php
+++ b/src/php/Compiler/Ast/PhpArraySetNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class PhpArraySetNode extends Node
@@ -14,7 +14,7 @@ final class PhpArraySetNode extends Node
     private Node $valueExpr;
 
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         Node $arrayExpr,
         Node $accessExpr,
         Node $valueExpr,

--- a/src/php/Compiler/Ast/PhpArrayUnsetNode.php
+++ b/src/php/Compiler/Ast/PhpArrayUnsetNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class PhpArrayUnsetNode extends Node
@@ -13,7 +13,7 @@ final class PhpArrayUnsetNode extends Node
     private Node $accessExpr;
 
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         Node $arrayExpr,
         Node $accessExpr,
         ?SourceLocation $sourceLocation = null

--- a/src/php/Compiler/Ast/PhpClassNameNode.php
+++ b/src/php/Compiler/Ast/PhpClassNameNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
@@ -12,7 +12,7 @@ final class PhpClassNameNode extends Node
 {
     private Symbol $name;
 
-    public function __construct(NodeEnvironment $env, Symbol $name, ?SourceLocation $sourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, Symbol $name, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct($env, $sourceLocation);
         $this->name = $name;

--- a/src/php/Compiler/Ast/PhpNewNode.php
+++ b/src/php/Compiler/Ast/PhpNewNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class PhpNewNode extends Node
@@ -18,7 +18,7 @@ final class PhpNewNode extends Node
      * @param Node[] $args
      */
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         Node $classExpr,
         array $args,
         ?SourceLocation $sourceLocation = null

--- a/src/php/Compiler/Ast/PhpObjectCallNode.php
+++ b/src/php/Compiler/Ast/PhpObjectCallNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class PhpObjectCallNode extends Node
@@ -15,7 +15,7 @@ final class PhpObjectCallNode extends Node
     private bool $methodCall;
 
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         Node $targetExpr,
         Node $callExpr,
         bool $isStatic,

--- a/src/php/Compiler/Ast/PhpVarNode.php
+++ b/src/php/Compiler/Ast/PhpVarNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class PhpVarNode extends Node
@@ -47,7 +47,7 @@ final class PhpVarNode extends Node
 
     private string $name;
 
-    public function __construct(NodeEnvironment $env, string $name, ?SourceLocation $sourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, string $name, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct($env, $sourceLocation);
         $this->name = $name;

--- a/src/php/Compiler/Ast/PropertyOrConstantAccessNode.php
+++ b/src/php/Compiler/Ast/PropertyOrConstantAccessNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
 
@@ -12,7 +12,7 @@ final class PropertyOrConstantAccessNode extends Node
 {
     private Symbol $name;
 
-    public function __construct(NodeEnvironment $env, Symbol $name, ?SourceLocation $sourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, Symbol $name, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct($env, $sourceLocation);
         $this->name = $name;

--- a/src/php/Compiler/Ast/QuoteNode.php
+++ b/src/php/Compiler/Ast/QuoteNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\AbstractType;
 use Phel\Lang\SourceLocation;
 
@@ -16,7 +16,7 @@ final class QuoteNode extends Node
     /**
      * @param AbstractType|string|float|int|bool|null $value
      */
-    public function __construct(NodeEnvironment $env, $value, ?SourceLocation $sourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, $value, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct($env, $sourceLocation);
         $this->value = $value;

--- a/src/php/Compiler/Ast/RecurNode.php
+++ b/src/php/Compiler/Ast/RecurNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Compiler\RecurFrame;
 use Phel\Lang\SourceLocation;
 
@@ -19,7 +19,7 @@ final class RecurNode extends Node
      * @param Node[] $expressions
      */
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         RecurFrame $frame,
         array $expressions,
         ?SourceLocation $sourceLocation = null

--- a/src/php/Compiler/Ast/TableNode.php
+++ b/src/php/Compiler/Ast/TableNode.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class TableNode extends Node
 {
     private array $keyValues;
 
-    public function __construct(NodeEnvironment $env, array $keyValues, ?SourceLocation $sourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, array $keyValues, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct($env, $sourceLocation);
         $this->keyValues = $keyValues;

--- a/src/php/Compiler/Ast/ThrowNode.php
+++ b/src/php/Compiler/Ast/ThrowNode.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class ThrowNode extends Node
 {
     private Node $exceptionExpr;
 
-    public function __construct(NodeEnvironment $env, Node $exceptionExpr, ?SourceLocation $sourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, Node $exceptionExpr, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct($env, $sourceLocation);
         $this->exceptionExpr = $exceptionExpr;

--- a/src/php/Compiler/Ast/TryNode.php
+++ b/src/php/Compiler/Ast/TryNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class TryNode extends Node
@@ -17,7 +17,7 @@ final class TryNode extends Node
     private ?Node $finally;
 
     public function __construct(
-        NodeEnvironment $env,
+        NodeEnvironmentInterface $env,
         Node $body,
         array $catches,
         ?Node $finally = null,

--- a/src/php/Compiler/Ast/TupleNode.php
+++ b/src/php/Compiler/Ast/TupleNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phel\Compiler\Ast;
 
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\SourceLocation;
 
 final class TupleNode extends Node
@@ -15,7 +15,7 @@ final class TupleNode extends Node
     /**
      * @param Node[] $args
      */
-    public function __construct(NodeEnvironment $env, array $args, ?SourceLocation $sourceLocation = null)
+    public function __construct(NodeEnvironmentInterface $env, array $args, ?SourceLocation $sourceLocation = null)
     {
         parent::__construct($env, $sourceLocation);
         $this->args = $args;

--- a/src/php/Compiler/Emitter/OutputEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter.php
@@ -9,7 +9,7 @@ use Phel\Compiler\Emitter\OutputEmitter\LiteralEmitter;
 use Phel\Compiler\Emitter\OutputEmitter\Munge;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitterFactory;
 use Phel\Compiler\Emitter\OutputEmitter\SourceMap\SourceMapGenerator;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\AbstractType;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
@@ -139,21 +139,21 @@ final class OutputEmitter implements OutputEmitterInterface
         );
     }
 
-    public function emitContextPrefix(NodeEnvironment $env, ?SourceLocation $sl = null): void
+    public function emitContextPrefix(NodeEnvironmentInterface $env, ?SourceLocation $sl = null): void
     {
-        if ($env->getContext() === NodeEnvironment::CONTEXT_RETURN) {
+        if ($env->getContext() === NodeEnvironmentInterface::CONTEXT_RETURN) {
             $this->emitStr('return ', $sl);
         }
     }
 
-    public function emitContextSuffix(NodeEnvironment $env, ?SourceLocation $sl = null): void
+    public function emitContextSuffix(NodeEnvironmentInterface $env, ?SourceLocation $sl = null): void
     {
-        if ($env->getContext() !== NodeEnvironment::CONTEXT_EXPRESSION) {
+        if ($env->getContext() !== NodeEnvironmentInterface::CONTEXT_EXPRESSION) {
             $this->emitStr(';', $sl);
         }
     }
 
-    public function emitFnWrapPrefix(NodeEnvironment $env, ?SourceLocation $sl = null): void
+    public function emitFnWrapPrefix(NodeEnvironmentInterface $env, ?SourceLocation $sl = null): void
     {
         $this->emitStr('(function()', $sl);
         if (count($env->getLocals()) > 0) {

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/DoEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/DoEmitter.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Ast\DoNode;
 use Phel\Compiler\Ast\Node;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 
 final class DoEmitter implements NodeEmitter
 {
@@ -17,7 +17,7 @@ final class DoEmitter implements NodeEmitter
     {
         assert($node instanceof DoNode);
 
-        $wrapFn = count($node->getStmts()) > 0 && $node->getEnv()->getContext() === NodeEnvironment::CONTEXT_EXPRESSION;
+        $wrapFn = count($node->getStmts()) > 0 && $node->getEnv()->getContext() === NodeEnvironmentInterface::CONTEXT_EXPRESSION;
         if ($wrapFn) {
             $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
         }

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/ForeachEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/ForeachEmitter.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Ast\ForeachNode;
 use Phel\Compiler\Ast\Node;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 
 final class ForeachEmitter implements NodeEmitter
 {
@@ -17,7 +17,7 @@ final class ForeachEmitter implements NodeEmitter
     {
         assert($node instanceof ForeachNode);
 
-        if ($node->getEnv()->getContext() !== NodeEnvironment::CONTEXT_STATEMENT) {
+        if ($node->getEnv()->getContext() !== NodeEnvironmentInterface::CONTEXT_STATEMENT) {
             $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
             $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
         }
@@ -37,7 +37,7 @@ final class ForeachEmitter implements NodeEmitter
         $this->outputEmitter->emitLine();
         $this->outputEmitter->emitStr('}', $node->getStartSourceLocation());
 
-        if ($node->getEnv()->getContext() !== NodeEnvironment::CONTEXT_STATEMENT) {
+        if ($node->getEnv()->getContext() !== NodeEnvironmentInterface::CONTEXT_STATEMENT) {
             $this->outputEmitter->emitLine();
             $this->outputEmitter->emitStr('return null;', $node->getStartSourceLocation());
             $this->outputEmitter->emitFnWrapSuffix($node->getStartSourceLocation());

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/IfEmitter.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Ast\IfNode;
 use Phel\Compiler\Ast\Node;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 
 final class IfEmitter implements NodeEmitter
 {
@@ -17,7 +17,7 @@ final class IfEmitter implements NodeEmitter
     {
         assert($node instanceof IfNode);
 
-        if ($node->getEnv()->getContext() === NodeEnvironment::CONTEXT_EXPRESSION) {
+        if ($node->getEnv()->getContext() === NodeEnvironmentInterface::CONTEXT_EXPRESSION) {
             $this->outputEmitter->emitStr('((\Phel\Lang\Truthy::isTruthy(', $node->getStartSourceLocation());
             $this->outputEmitter->emitNode($node->getTestExpr());
             $this->outputEmitter->emitStr(')) ? ', $node->getStartSourceLocation());

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/LetEmitter.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Ast\LetNode;
 use Phel\Compiler\Ast\Node;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 
 final class LetEmitter implements NodeEmitter
 {
@@ -17,7 +17,7 @@ final class LetEmitter implements NodeEmitter
     {
         assert($node instanceof LetNode);
 
-        $wrapFn = $node->getEnv()->getContext() === NodeEnvironment::CONTEXT_EXPRESSION;
+        $wrapFn = $node->getEnv()->getContext() === NodeEnvironmentInterface::CONTEXT_EXPRESSION;
         if ($wrapFn) {
             $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
         }

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/LiteralEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/LiteralEmitter.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Ast\LiteralNode;
 use Phel\Compiler\Ast\Node;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 
 final class LiteralEmitter implements NodeEmitter
 {
@@ -17,7 +17,7 @@ final class LiteralEmitter implements NodeEmitter
     {
         assert($node instanceof LiteralNode);
 
-        if (!($node->getEnv()->getContext() === NodeEnvironment::CONTEXT_STATEMENT)) {
+        if (!($node->getEnv()->getContext() === NodeEnvironmentInterface::CONTEXT_STATEMENT)) {
             $this->outputEmitter->emitContextPrefix($node->getEnv(), $node->getStartSourceLocation());
             $this->outputEmitter->emitLiteral($node->getValue());
             $this->outputEmitter->emitContextSuffix($node->getEnv(), $node->getStartSourceLocation());

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/ThrowEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/ThrowEmitter.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Ast\Node;
 use Phel\Compiler\Ast\ThrowNode;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 
 final class ThrowEmitter implements NodeEmitter
 {
@@ -17,7 +17,7 @@ final class ThrowEmitter implements NodeEmitter
     {
         assert($node instanceof ThrowNode);
 
-        if ($node->getEnv()->getContext() === NodeEnvironment::CONTEXT_EXPRESSION) {
+        if ($node->getEnv()->getContext() === NodeEnvironmentInterface::CONTEXT_EXPRESSION) {
             $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
         }
 
@@ -25,7 +25,7 @@ final class ThrowEmitter implements NodeEmitter
         $this->outputEmitter->emitNode($node->getExceptionExpr());
         $this->outputEmitter->emitStr(';', $node->getStartSourceLocation());
 
-        if ($node->getEnv()->getContext() === NodeEnvironment::CONTEXT_EXPRESSION) {
+        if ($node->getEnv()->getContext() === NodeEnvironmentInterface::CONTEXT_EXPRESSION) {
             $this->outputEmitter->emitFnWrapSuffix($node->getStartSourceLocation());
         }
     }

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/TryEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/TryEmitter.php
@@ -7,7 +7,7 @@ namespace Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
 use Phel\Compiler\Ast\Node;
 use Phel\Compiler\Ast\TryNode;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitter;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 
 final class TryEmitter implements NodeEmitter
 {
@@ -18,7 +18,7 @@ final class TryEmitter implements NodeEmitter
         assert($node instanceof TryNode);
 
         if ($node->getFinally() || count($node->getCatches()) > 0) {
-            if ($node->getEnv()->getContext() === NodeEnvironment::CONTEXT_EXPRESSION) {
+            if ($node->getEnv()->getContext() === NodeEnvironmentInterface::CONTEXT_EXPRESSION) {
                 $this->outputEmitter->emitFnWrapPrefix($node->getEnv(), $node->getStartSourceLocation());
             }
 
@@ -37,7 +37,7 @@ final class TryEmitter implements NodeEmitter
                 $this->emitFinally($node->getFinally());
             }
 
-            if ($node->getEnv()->getContext() === NodeEnvironment::CONTEXT_EXPRESSION) {
+            if ($node->getEnv()->getContext() === NodeEnvironmentInterface::CONTEXT_EXPRESSION) {
                 $this->outputEmitter->emitFnWrapSuffix($node->getStartSourceLocation());
             }
         } else {

--- a/src/php/Compiler/Emitter/OutputEmitterInterface.php
+++ b/src/php/Compiler/Emitter/OutputEmitterInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phel\Compiler\Emitter;
 
 use Phel\Compiler\Ast\Node;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\AbstractType;
 use Phel\Lang\SourceLocation;
 use Phel\Lang\Symbol;
@@ -26,11 +26,11 @@ interface OutputEmitterInterface
 
     public function emitGlobalBaseMeta(string $namespace, Symbol $name): void;
 
-    public function emitContextPrefix(NodeEnvironment $env, ?SourceLocation $sl = null): void;
+    public function emitContextPrefix(NodeEnvironmentInterface $env, ?SourceLocation $sl = null): void;
 
-    public function emitContextSuffix(NodeEnvironment $env, ?SourceLocation $sl = null): void;
+    public function emitContextSuffix(NodeEnvironmentInterface $env, ?SourceLocation $sl = null): void;
 
-    public function emitFnWrapPrefix(NodeEnvironment $env, ?SourceLocation $sl = null): void;
+    public function emitFnWrapPrefix(NodeEnvironmentInterface $env, ?SourceLocation $sl = null): void;
 
     public function emitPhpVariable(
         Symbol $symbol,

--- a/src/php/Compiler/EvalCompiler.php
+++ b/src/php/Compiler/EvalCompiler.php
@@ -60,7 +60,7 @@ final class EvalCompiler implements EvalCompilerInterface
         try {
             $node = $this->analyzer->analyze(
                 $readerResult->getAst(),
-                NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_RETURN)
+                NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_RETURN)
             );
 
             $code = $this->emitter->emitNodeAsString($node);

--- a/src/php/Compiler/GlobalEnvironment.php
+++ b/src/php/Compiler/GlobalEnvironment.php
@@ -112,7 +112,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         $this->refers[$inNamespace][$fnName->getName()] = $ns;
     }
 
-    public function resolve(Symbol $name, NodeEnvironment $env): ?Node
+    public function resolve(Symbol $name, NodeEnvironmentInterface $env): ?Node
     {
         $strName = $name->getName();
 
@@ -174,7 +174,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         return null;
     }
 
-    private function resolveWithAlias(Symbol $name, NodeEnvironment $env): ?GlobalVarNode
+    private function resolveWithAlias(Symbol $name, NodeEnvironmentInterface $env): ?GlobalVarNode
     {
         $alias = $name->getNamespace();
         $finalName = Symbol::create($name->getName());
@@ -196,7 +196,7 @@ final class GlobalEnvironment implements GlobalEnvironmentInterface
         return null;
     }
 
-    private function resolveWithoutAlias(Symbol $name, NodeEnvironment $env): ?GlobalVarNode
+    private function resolveWithoutAlias(Symbol $name, NodeEnvironmentInterface $env): ?GlobalVarNode
     {
         $ns = $this->getNs();
         if (isset($this->refers[$this->ns][$name->getName()])) {

--- a/src/php/Compiler/GlobalEnvironmentInterface.php
+++ b/src/php/Compiler/GlobalEnvironmentInterface.php
@@ -30,7 +30,7 @@ interface GlobalEnvironmentInterface
 
     public function addRefer(string $inNamespace, Symbol $fnName, Symbol $ns): void;
 
-    public function resolve(Symbol $name, NodeEnvironment $env): ?Node;
+    public function resolve(Symbol $name, NodeEnvironmentInterface $env): ?Node;
 
     public function setAllowPrivateAccess(bool $allowPrivateAccess): void;
 }

--- a/src/php/Compiler/NodeEnvironment.php
+++ b/src/php/Compiler/NodeEnvironment.php
@@ -6,12 +6,8 @@ namespace Phel\Compiler;
 
 use Phel\Lang\Symbol;
 
-final class NodeEnvironment
+final class NodeEnvironment implements NodeEnvironmentInterface
 {
-    public const CONTEXT_EXPRESSION = 'expression';
-    public const CONTEXT_STATEMENT = 'statement';
-    public const CONTEXT_RETURN = 'return';
-
     /**
      * A list of local symbols.
      *
@@ -63,7 +59,7 @@ final class NodeEnvironment
         $this->boundTo = $boundTo ?? '';
     }
 
-    public static function empty(): NodeEnvironment
+    public static function empty(): NodeEnvironmentInterface
     {
         return new NodeEnvironment([], self::CONTEXT_STATEMENT, [], []);
     }
@@ -105,7 +101,7 @@ final class NodeEnvironment
         return $this->context;
     }
 
-    public function withMergedLocals(array $locals): NodeEnvironment
+    public function withMergedLocals(array $locals): NodeEnvironmentInterface
     {
         $allLocalSymbols = array_merge(
             $this->locals,
@@ -118,7 +114,7 @@ final class NodeEnvironment
         return $this->withLocals(array_unique($allLocalSymbols));
     }
 
-    public function withShadowedLocal(Symbol $local, Symbol $shadow): NodeEnvironment
+    public function withShadowedLocal(Symbol $local, Symbol $shadow): NodeEnvironmentInterface
     {
         $result = clone $this;
         $result->shadowed = array_merge($this->shadowed, [$local->getName() => $shadow]);
@@ -126,7 +122,7 @@ final class NodeEnvironment
         return $result;
     }
 
-    public function withLocals(array $locals): NodeEnvironment
+    public function withLocals(array $locals): NodeEnvironmentInterface
     {
         $result = clone $this;
         $result->locals = $locals;
@@ -134,7 +130,7 @@ final class NodeEnvironment
         return $result;
     }
 
-    public function withContext(string $context): NodeEnvironment
+    public function withContext(string $context): NodeEnvironmentInterface
     {
         $result = clone $this;
         $result->context = $context;
@@ -142,7 +138,7 @@ final class NodeEnvironment
         return $result;
     }
 
-    public function withAddedRecurFrame(RecurFrame $frame): NodeEnvironment
+    public function withAddedRecurFrame(RecurFrame $frame): NodeEnvironmentInterface
     {
         $result = clone $this;
         $result->recurFrames = array_merge($this->recurFrames, [$frame]);
@@ -150,7 +146,7 @@ final class NodeEnvironment
         return $result;
     }
 
-    public function withDisallowRecurFrame(): NodeEnvironment
+    public function withDisallowRecurFrame(): NodeEnvironmentInterface
     {
         $result = clone $this;
         $result->recurFrames = array_merge($this->recurFrames, [null]);
@@ -158,7 +154,7 @@ final class NodeEnvironment
         return $result;
     }
 
-    public function withBoundTo(string $boundTo): NodeEnvironment
+    public function withBoundTo(string $boundTo): NodeEnvironmentInterface
     {
         $result = clone $this;
         $result->boundTo = $boundTo;
@@ -166,7 +162,7 @@ final class NodeEnvironment
         return $result;
     }
 
-    public function withDefAllowed(bool $defAllowed): NodeEnvironment
+    public function withDefAllowed(bool $defAllowed): NodeEnvironmentInterface
     {
         $result = clone $this;
         $result->defAllowed = $defAllowed;

--- a/src/php/Compiler/NodeEnvironmentInterface.php
+++ b/src/php/Compiler/NodeEnvironmentInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Compiler;
+
+use Phel\Lang\Symbol;
+
+interface NodeEnvironmentInterface
+{
+    public const CONTEXT_EXPRESSION = 'expression';
+    public const CONTEXT_STATEMENT = 'statement';
+    public const CONTEXT_RETURN = 'return';
+
+    /**
+     * @return Symbol[]
+     */
+    public function getLocals(): array;
+
+    public function hasLocal(Symbol $x): bool;
+
+    /**
+     * Gets the shadowed name of a local variable.
+     *
+     * @param Symbol $local The local variable
+     */
+    public function getShadowed(Symbol $local): ?Symbol;
+
+    public function isShadowed(Symbol $local): bool;
+
+    public function getContext(): string;
+
+    public function withMergedLocals(array $locals): NodeEnvironmentInterface;
+
+    public function withShadowedLocal(Symbol $local, Symbol $shadow): NodeEnvironmentInterface;
+
+    public function withLocals(array $locals): NodeEnvironmentInterface;
+
+    public function withContext(string $context): NodeEnvironmentInterface;
+
+    public function withAddedRecurFrame(RecurFrame $frame): NodeEnvironmentInterface;
+
+    public function withDisallowRecurFrame(): NodeEnvironmentInterface;
+
+    public function withBoundTo(string $boundTo): NodeEnvironmentInterface;
+
+    public function withDefAllowed(bool $defAllowed): NodeEnvironmentInterface;
+
+    public function getCurrentRecurFrame(): ?RecurFrame;
+
+    public function getBoundTo(): string;
+
+    public function isDefAllowed(): bool;
+}

--- a/tests/php/Unit/Compiler/Analyzer/AnalyzeTupleTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/AnalyzeTupleTest.php
@@ -26,9 +26,10 @@ use Phel\Compiler\Ast\RecurNode;
 use Phel\Compiler\Ast\ThrowNode;
 use Phel\Compiler\Ast\TryNode;
 use Phel\Compiler\GlobalEnvironment;
+use Phel\Compiler\NodeEnvironment;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
-use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use  Phel\Compiler\RecurFrame;
 use PHPUnit\Framework\TestCase;
 
@@ -153,7 +154,7 @@ final class AnalyzeTupleTest extends TestCase
     {
         $tuple = Tuple::create(Symbol::create(Symbol::NAME_RECUR), 1);
         $recurFrames = [new RecurFrame([Symbol::create(Symbol::NAME_FOREACH)])];
-        $nodeEnv = new NodeEnvironment([], NodeEnvironment::CONTEXT_STATEMENT, [], $recurFrames);
+        $nodeEnv = new NodeEnvironment([], NodeEnvironmentInterface::CONTEXT_STATEMENT, [], $recurFrames);
         self::assertInstanceOf(RecurNode::class, $this->tupleAnalyzer->analyze($tuple, $nodeEnv));
     }
 

--- a/tests/php/Unit/Compiler/Analyzer/TupleSymbol/ApplySymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TupleSymbol/ApplySymbolTest.php
@@ -8,11 +8,11 @@ use Phel\Compiler\Analyzer;
 use Phel\Compiler\Analyzer\TupleSymbol\ApplySymbol;
 use Phel\Compiler\AnalyzerInterface;
 use Phel\Compiler\Ast\CallNode;
+use Phel\Compiler\NodeEnvironment;
 use Phel\Exceptions\PhelCodeException;
 use Phel\Compiler\GlobalEnvironment;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
-use Phel\Compiler\NodeEnvironment;
 use PHPUnit\Framework\TestCase;
 
 final class ApplySymbolTest extends TestCase

--- a/tests/php/Unit/Compiler/Analyzer/TupleSymbol/DefStructSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TupleSymbol/DefStructSymbolTest.php
@@ -7,11 +7,11 @@ namespace PhelTest\Unit\Compiler\Analyzer\TupleSymbol;
 use Phel\Compiler\Analyzer;
 use Phel\Compiler\Analyzer\TupleSymbol\DefStructSymbol;
 use Phel\Compiler\AnalyzerInterface;
+use Phel\Compiler\NodeEnvironment;
 use Phel\Exceptions\PhelCodeException;
 use Phel\Compiler\GlobalEnvironment;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
-use Phel\Compiler\NodeEnvironment;
 use PHPUnit\Framework\TestCase;
 
 final class DefStructSymbolTest extends TestCase

--- a/tests/php/Unit/Compiler/Analyzer/TupleSymbol/DefSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TupleSymbol/DefSymbolTest.php
@@ -8,12 +8,12 @@ use Phel\Compiler\Analyzer;
 use Phel\Compiler\Analyzer\TupleSymbol\DefSymbol;
 use Phel\Compiler\AnalyzerInterface;
 use Phel\Compiler\Ast\LiteralNode;
-use Phel\Exceptions\PhelCodeException;
 use Phel\Compiler\GlobalEnvironment;
+use Phel\Compiler\NodeEnvironment;
+use Phel\Exceptions\PhelCodeException;
 use Phel\Lang\Symbol;
 use Phel\Lang\Table;
 use Phel\Lang\Tuple;
-use Phel\Compiler\NodeEnvironment;
 use PHPUnit\Framework\TestCase;
 
 final class DefSymbolTest extends TestCase

--- a/tests/php/Unit/Compiler/Analyzer/TupleSymbol/DoSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TupleSymbol/DoSymbolTest.php
@@ -8,11 +8,11 @@ use Phel\Compiler\Analyzer;
 use Phel\Compiler\Analyzer\TupleSymbol\DoSymbol;
 use Phel\Compiler\AnalyzerInterface;
 use Phel\Compiler\Ast\DoNode;
+use Phel\Compiler\NodeEnvironment;
 use Phel\Exceptions\PhelCodeException;
 use Phel\Compiler\GlobalEnvironment;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
-use Phel\Compiler\NodeEnvironment;
 use PHPUnit\Framework\TestCase;
 
 final class DoSymbolTest extends TestCase

--- a/tests/php/Unit/Compiler/Analyzer/TupleSymbol/FnSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TupleSymbol/FnSymbolTest.php
@@ -11,12 +11,12 @@ use Phel\Compiler\AnalyzerInterface;
 use Phel\Compiler\Ast\DoNode;
 use Phel\Compiler\Ast\FnNode;
 use Phel\Compiler\Ast\LetNode;
+use Phel\Compiler\NodeEnvironment;
 use Phel\Exceptions\PhelCodeException;
 use Phel\Compiler\GlobalEnvironment;
 use Phel\Lang\Symbol;
 use Phel\Lang\Table;
 use Phel\Lang\Tuple;
-use Phel\Compiler\NodeEnvironment;
 use PHPUnit\Framework\TestCase;
 
 final class FnSymbolTest extends TestCase

--- a/tests/php/Unit/Compiler/Analyzer/TupleSymbol/ForeachSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TupleSymbol/ForeachSymbolTest.php
@@ -7,12 +7,12 @@ namespace PhelTest\Unit\Compiler\Analyzer\TupleSymbol;
 use Phel\Compiler\Analyzer;
 use Phel\Compiler\Analyzer\TupleSymbol\ForeachSymbol;
 use Phel\Compiler\Ast\ForeachNode;
+use Phel\Compiler\NodeEnvironment;
 use Phel\Exceptions\PhelCodeException;
 use Phel\Compiler\GlobalEnvironment;
 use Phel\Lang\Symbol;
 use Phel\Lang\Table;
 use Phel\Lang\Tuple;
-use Phel\Compiler\NodeEnvironment;
 use PHPUnit\Framework\TestCase;
 
 final class ForeachSymbolTest extends TestCase

--- a/tests/php/Unit/Compiler/Analyzer/TupleSymbol/IfSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TupleSymbol/IfSymbolTest.php
@@ -8,11 +8,11 @@ use Generator;
 use Phel\Compiler\Analyzer;
 use Phel\Compiler\Analyzer\TupleSymbol\IfSymbol;
 use Phel\Compiler\Ast\IfNode;
+use Phel\Compiler\NodeEnvironment;
 use Phel\Exceptions\PhelCodeException;
 use Phel\Compiler\GlobalEnvironment;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
-use Phel\Compiler\NodeEnvironment;
 use PHPUnit\Framework\TestCase;
 
 final class IfSymbolTest extends TestCase

--- a/tests/php/Unit/Compiler/Analyzer/TupleSymbol/PhpObjectCallSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TupleSymbol/PhpObjectCallSymbolTest.php
@@ -10,11 +10,11 @@ use Phel\Compiler\AnalyzerInterface;
 use Phel\Compiler\Ast\MethodCallNode;
 use Phel\Compiler\Ast\PhpClassNameNode;
 use Phel\Compiler\Ast\PropertyOrConstantAccessNode;
+use Phel\Compiler\NodeEnvironment;
 use Phel\Exceptions\PhelCodeException;
 use Phel\Compiler\GlobalEnvironment;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
-use Phel\Compiler\NodeEnvironment;
 use PHPUnit\Framework\TestCase;
 
 final class PhpObjectCallSymbolTest extends TestCase

--- a/tests/php/Unit/Compiler/Analyzer/TupleSymbol/QuoteSymbolTest.php
+++ b/tests/php/Unit/Compiler/Analyzer/TupleSymbol/QuoteSymbolTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace PhelTest\Unit\Compiler\Analyzer\TupleSymbol;
 
 use Phel\Compiler\Analyzer\TupleSymbol\QuoteSymbol;
+use Phel\Compiler\NodeEnvironment;
 use Phel\Exceptions\PhelCodeException;
 use Phel\Lang\Symbol;
 use Phel\Lang\Tuple;
-use Phel\Compiler\NodeEnvironment;
 use PHPUnit\Framework\TestCase;
 
 final class QuoteSymbolTest extends TestCase

--- a/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
+++ b/tests/php/Unit/Compiler/Emitter/OutputEmitter/NodeEmitter/ApplyEmitterTest.php
@@ -12,6 +12,7 @@ use Phel\Compiler\Ast\TupleNode;
 use Phel\Compiler\CompilerFactory;
 use Phel\Compiler\Emitter\OutputEmitter\NodeEmitter\ApplyEmitter;
 use Phel\Compiler\NodeEnvironment;
+use Phel\Compiler\NodeEnvironmentInterface;
 use Phel\Lang\Symbol;
 use PHPUnit\Framework\TestCase;
 
@@ -31,10 +32,10 @@ final class ApplyEmitterTest extends TestCase
     {
         $node = new PhpVarNode(NodeEnvironment::empty(), '+');
         $args = [
-            new TupleNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), [
-                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), 2),
-                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), 3),
-                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), 4),
+            new TupleNode(NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION), [
+                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION), 2),
+                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION), 3),
+                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION), 4),
             ]),
         ];
 
@@ -50,9 +51,9 @@ final class ApplyEmitterTest extends TestCase
     {
         $node = new PhpVarNode(NodeEnvironment::empty(), 'str');
         $args = [
-            new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), 'abc'),
-            new TupleNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), [
-                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), 'def'),
+            new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION), 'abc'),
+            new TupleNode(NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION), [
+                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION), 'def'),
             ]),
         ];
 
@@ -67,15 +68,15 @@ final class ApplyEmitterTest extends TestCase
         $fnNode = new FnNode(
             NodeEnvironment::empty(),
             [Symbol::create('x')],
-            new PhpVarNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_RETURN), 'x'),
+            new PhpVarNode(NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_RETURN), 'x'),
             [],
             $isVariadic = true,
             $recurs = false
         );
 
         $args = [
-            new TupleNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), [
-                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironment::CONTEXT_EXPRESSION), 1),
+            new TupleNode(NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION), [
+                new LiteralNode(NodeEnvironment::empty()->withContext(NodeEnvironmentInterface::CONTEXT_EXPRESSION), 1),
             ]),
         ];
 


### PR DESCRIPTION
## 📚 Description

Invert the NodeEnvironment dependencies by creating an interface for it.

I have some doubts about the usage of the constants from the interface directly:
``` php 
interface NodeEnvironmentInterface
{
    public const CONTEXT_EXPRESSION = 'expression';
    public const CONTEXT_STATEMENT = 'statement';
    public const CONTEXT_RETURN = 'return';
    // ...
#  -----------------------------------------
NodeEnvironmentInterface::CONTEXT_EXPRESSION
``` 
But I decided to leave them there (in the interface) for simplicity right now.

Apart from this, I think it's important to mention that the interface has too many functions, which is a smell for the "Interface Segregation Principle" violation, but that's out of the scope of this PR.

## 🔖 Changes

- Use the `NodeEnvironmentInterface` as an argument where its concrete `NodeEnvironment` was specified.
