### PR TITLE
Creating runtime module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "phel/phel-composer-plugin": "dev-using-runtime-factory"
+        "phel/phel-composer-plugin": "dev-master"
     },
     "require-dev": {
         "ext-readline": "*",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "phel/phel-composer-plugin": "dev-master"
+        "phel/phel-composer-plugin": "dev-using-runtime-factory"
     },
     "require-dev": {
         "ext-readline": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c82228ed8952938e9d6d6763af08ff8",
+    "content-hash": "163f89c5620de8e8da75fc44ecbb37de",
     "packages": [
         {
             "name": "phel/phel-composer-plugin",
-            "version": "dev-master",
+            "version": "dev-using-runtime-factory",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jenshaase/phel-composer-plugin.git",
-                "reference": "0f20e4e7e8052bfc9cdf662ae10282cc06396cf0"
+                "reference": "fe0d287ae9bce0a7e47fb01ec196a0734c463d02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jenshaase/phel-composer-plugin/zipball/0f20e4e7e8052bfc9cdf662ae10282cc06396cf0",
-                "reference": "0f20e4e7e8052bfc9cdf662ae10282cc06396cf0",
+                "url": "https://api.github.com/repos/jenshaase/phel-composer-plugin/zipball/fe0d287ae9bce0a7e47fb01ec196a0734c463d02",
+                "reference": "fe0d287ae9bce0a7e47fb01ec196a0734c463d02",
                 "shasum": ""
             },
             "require": {
@@ -30,7 +30,6 @@
                 "phpunit/phpunit": "^9",
                 "vimeo/psalm": "^3.11"
             },
-            "default-branch": true,
             "type": "composer-plugin",
             "extra": {
                 "class": "Phel\\Composer\\Plugin"
@@ -62,9 +61,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jenshaase/phel-composer-plugin/issues",
-                "source": "https://github.com/jenshaase/phel-composer-plugin/tree/master"
+                "source": "https://github.com/jenshaase/phel-composer-plugin/tree/using-runtime-factory"
             },
-            "time": "2020-10-25T11:03:37+00:00"
+            "time": "2020-12-08T16:38:28+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "163f89c5620de8e8da75fc44ecbb37de",
+    "content-hash": "1c82228ed8952938e9d6d6763af08ff8",
     "packages": [
         {
             "name": "phel/phel-composer-plugin",
-            "version": "dev-using-runtime-factory",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jenshaase/phel-composer-plugin.git",
-                "reference": "fe0d287ae9bce0a7e47fb01ec196a0734c463d02"
+                "reference": "752a223af4f2bf0d1ec3bcc68297db2cdae87585"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jenshaase/phel-composer-plugin/zipball/fe0d287ae9bce0a7e47fb01ec196a0734c463d02",
-                "reference": "fe0d287ae9bce0a7e47fb01ec196a0734c463d02",
+                "url": "https://api.github.com/repos/jenshaase/phel-composer-plugin/zipball/752a223af4f2bf0d1ec3bcc68297db2cdae87585",
+                "reference": "752a223af4f2bf0d1ec3bcc68297db2cdae87585",
                 "shasum": ""
             },
             "require": {
@@ -30,6 +30,7 @@
                 "phpunit/phpunit": "^9",
                 "vimeo/psalm": "^3.11"
             },
+            "default-branch": true,
             "type": "composer-plugin",
             "extra": {
                 "class": "Phel\\Composer\\Plugin"
@@ -61,9 +62,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jenshaase/phel-composer-plugin/issues",
-                "source": "https://github.com/jenshaase/phel-composer-plugin/tree/using-runtime-factory"
+                "source": "https://github.com/jenshaase/phel-composer-plugin/tree/master"
             },
-            "time": "2020-12-08T16:38:28+00:00"
+            "time": "2020-12-13T13:20:19+00:00"
         }
     ],
     "packages-dev": [

--- a/doc/build-api-page.php
+++ b/doc/build-api-page.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 use Phel\Lang\Keyword;
 use Phel\Lang\Table;
-use Phel\Runtime;
+use Phel\Runtime\RuntimeFactory;
 
 require __DIR__ .'/../vendor/autoload.php';
 
-$rt = Runtime::initialize();
+$rt = RuntimeFactory::initialize();
 $rt->addPath('phel\\', [__DIR__ . '/../src/phel']);
 $rt->loadNs('phel\core');
 $rt->loadNs('phel\http');

--- a/doc/content/documentation/configuration.md
+++ b/doc/content/documentation/configuration.md
@@ -86,11 +86,11 @@ It is possible to manually initialize and configure the Runtime as shown in this
 // src/index.php
 <?php
 
-use Phel\Runtime;
+use Phel\Runtime\RuntimeFactory;
 
 require __DIR__ .'/../vendor/autoload.php';
 
-$rt = Runtime::initialize();
+$rt = RuntimeFactory::initialize();
 $rt->addPath('hello-world\\', [__DIR__]);
 
 $rt->loadNs('phel\core');

--- a/src/phel/test.phel
+++ b/src/phel/test.phel
@@ -1,6 +1,6 @@
 (ns phel\test
   (:use Phel\Lang\Symbol)
-  (:use Phel\Runtime)
+  (:use Phel\Runtime\RuntimeFactory)
   (:use Phel\Compiler\Emitter\OutputEmitter\Munge)
   (:use Phel\Exceptions\TextExceptionPrinter)
   (:use Throwable))
@@ -299,7 +299,7 @@
       (get-in php/$GLOBALS ["__phel" munge-ns fn-name]))))
 
 (defn- run-test [ns]
-  (let [rt (php/:: \Phel\Runtime (getInstance))
+  (let [rt (php/:: \Phel\Runtime\RuntimeFactory (getInstance))
         _ (php/-> rt (loadNs ns))
         tests (find-test-fns ns)
         ]

--- a/src/php/Command/CommandFactory.php
+++ b/src/php/Command/CommandFactory.php
@@ -12,7 +12,7 @@ use Phel\Command\Shared\NamespaceExtractorInterface;
 use Phel\Compiler\CompilerFactoryInterface;
 use Phel\Compiler\GlobalEnvironmentInterface;
 use Phel\Exceptions\TextExceptionPrinter;
-use Phel\RuntimeInterface;
+use Phel\Runtime\RuntimeInterface;
 
 final class CommandFactory implements CommandFactoryInterface
 {

--- a/src/php/Command/CommandFactoryInterface.php
+++ b/src/php/Command/CommandFactoryInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phel\Command;
 
 use Phel\Compiler\GlobalEnvironmentInterface;
-use Phel\RuntimeInterface;
+use Phel\Runtime\RuntimeInterface;
 
 interface CommandFactoryInterface
 {

--- a/src/php/Command/RunCommand.php
+++ b/src/php/Command/RunCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phel\Command;
 
 use Phel\Command\Shared\NamespaceExtractorInterface;
-use Phel\RuntimeInterface;
+use Phel\Runtime\RuntimeInterface;
 use RuntimeException;
 
 final class RunCommand

--- a/src/php/Command/TestCommand.php
+++ b/src/php/Command/TestCommand.php
@@ -6,7 +6,7 @@ namespace Phel\Command;
 
 use Phel\Command\Shared\NamespaceExtractorInterface;
 use Phel\Compiler\EvalCompilerInterface;
-use Phel\RuntimeInterface;
+use Phel\Runtime\RuntimeInterface;
 use RuntimeException;
 
 final class TestCommand

--- a/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/NodeEmitter/NsEmitter.php
@@ -20,13 +20,13 @@ final class NsEmitter implements NodeEmitter
 
         foreach ($node->getRequireNs() as $i => $ns) {
             $this->outputEmitter->emitLine(
-                '\Phel\Runtime::getInstance()->loadNs("' . addslashes($ns->getName()) . '");',
+                '\Phel\Runtime\RuntimeFactory::getInstance()->loadNs("' . addslashes($ns->getName()) . '");',
                 $ns->getStartLocation()
             );
         }
 
         $this->outputEmitter->emitLine(
-            '\Phel\Runtime::getInstance()->getEnv()->setNs("' . addslashes($node->getNamespace()) . '");',
+            '\Phel\Runtime\RuntimeFactory::getInstance()->getEnv()->setNs("' . addslashes($node->getNamespace()) . '");',
             $node->getStartSourceLocation()
         );
 

--- a/src/php/Compiler/Emitter/OutputEmitter/SourceMap/VLQ.php
+++ b/src/php/Compiler/Emitter/OutputEmitter/SourceMap/VLQ.php
@@ -8,14 +8,10 @@ use Exception;
 
 final class VLQ
 {
-    /**
-     * @var array<int, string>
-     */
+    /** @var array<int, string> */
     private array $integerToChar = [];
 
-    /**
-     * @var array<string, int>
-     */
+    /** @var array<string, int> */
     private array $charToInteger = [];
 
     private const CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';

--- a/src/php/Main.php
+++ b/src/php/Main.php
@@ -11,6 +11,8 @@ use Phel\Command\RunCommand;
 use Phel\Command\TestCommand;
 use Phel\Compiler\GlobalEnvironment;
 use Phel\Exceptions\ExitException;
+use Phel\Runtime\RuntimeFactory;
+use Phel\Runtime\RuntimeInterface;
 use RuntimeException;
 
 final class Main
@@ -67,7 +69,7 @@ HELP;
     private function executeReplCommand(): void
     {
         $globalEnv = new GlobalEnvironment();
-        Runtime::initialize($globalEnv)->loadNs('phel\core');
+        RuntimeFactory::initialize($globalEnv)->loadNs('phel\core');
 
         $this->commandFactory
             ->createReplCommand($globalEnv)

--- a/src/php/Runtime/Runtime.php
+++ b/src/php/Runtime/Runtime.php
@@ -2,42 +2,46 @@
 
 declare(strict_types=1);
 
-namespace Phel;
+namespace Phel\Runtime;
 
-use Phel\Compiler\CompilerFactory;
-use Phel\Compiler\GlobalEnvironment;
+use InvalidArgumentException;
+use Phel\Compiler\CompilerFactoryInterface;
 use Phel\Compiler\GlobalEnvironmentInterface;
 use Phel\Exceptions\CompilerException;
-use Phel\Exceptions\HtmlExceptionPrinter;
-use Phel\Exceptions\TextExceptionPrinter;
+use Phel\Exceptions\ExceptionPrinterInterface;
 use Phel\Lang\Keyword;
 use Phel\Lang\Symbol;
 use Phel\Lang\Table;
-use RuntimeException;
 use Throwable;
 
 class Runtime implements RuntimeInterface
 {
     protected GlobalEnvironmentInterface $globalEnv;
 
-    private static ?RuntimeInterface $instance = null;
+    private ExceptionPrinterInterface $exceptionPrinter;
+
+    private CompilerFactoryInterface $compilerFactory;
+
+    private ?string $cacheDirectory = null;
 
     /** @var string[] */
     private array $loadedNs = [];
 
     private array $paths = [];
 
-    private ?string $cacheDirectory = null;
-
-    private function __construct(
+    public function __construct(
         GlobalEnvironmentInterface $globalEnv,
+        ExceptionPrinterInterface $exceptionPrinter,
+        CompilerFactoryInterface $compilerFactory,
         ?string $cacheDirectory = null
     ) {
         set_exception_handler([$this, 'exceptionHandler']);
+        $this->addPath('phel\\', [__DIR__ . '/../phel']);
 
         $this->globalEnv = $globalEnv;
+        $this->exceptionPrinter = $exceptionPrinter;
+        $this->compilerFactory = $compilerFactory;
         $this->cacheDirectory = $cacheDirectory;
-        $this->addPath('phel\\', [__DIR__ . '/../phel']);
     }
 
     public function getEnv(): GlobalEnvironmentInterface
@@ -49,7 +53,7 @@ class Runtime implements RuntimeInterface
     {
         $length = strlen($namespacePrefix);
         if ('\\' !== $namespacePrefix[$length - 1]) {
-            throw new \InvalidArgumentException('A non-empty prefix must end with a namespace separator.');
+            throw new InvalidArgumentException('A non-empty prefix must end with a namespace separator.');
         }
 
         if (isset($this->paths[$namespacePrefix])) {
@@ -59,53 +63,12 @@ class Runtime implements RuntimeInterface
         }
     }
 
-    public static function initialize(
-        ?GlobalEnvironmentInterface $globalEnv = null,
-        ?string $cacheDirectory = null
-    ): self {
-        if (self::$instance !== null) {
-            throw new RuntimeException('Runtime is already initialized');
-        }
-
-        self::$instance = new self(
-            $globalEnv ?? new GlobalEnvironment(),
-            $cacheDirectory
-        );
-
-        return self::$instance;
-    }
-
-    /**
-     * @interal
-     */
-    public static function initializeNew(GlobalEnvironmentInterface $globalEnv, string $cacheDirectory = null): self
-    {
-        self::$instance = new self($globalEnv, $cacheDirectory);
-
-        return self::$instance;
-    }
-
-    public static function getInstance(): RuntimeInterface
-    {
-        if (null === self::$instance) {
-            throw new RuntimeException('Runtime must first be initialized. Call Runtime::initialize()');
-        }
-
-        return self::$instance;
-    }
-
     public function exceptionHandler(Throwable $exception): void
     {
-        if (PHP_SAPI === 'cli') {
-            $printer = TextExceptionPrinter::readableWithStyle();
-        } else {
-            $printer = HtmlExceptionPrinter::create();
-        }
-
         if ($exception instanceof CompilerException) {
-            $printer->printException($exception->getNestedException(), $exception->getCodeSnippet());
+            $this->exceptionPrinter->printException($exception->getNestedException(), $exception->getCodeSnippet());
         } else {
-            $printer->printStackTrace($exception);
+            $this->exceptionPrinter->printStackTrace($exception);
         }
     }
 
@@ -186,7 +149,7 @@ class Runtime implements RuntimeInterface
         $path = $this->getCachedFilePath($filename, $ns);
 
         if (!$path) {
-            throw new \InvalidArgumentException("Can not load cached file: {$filename}");
+            throw new InvalidArgumentException("Can not load cached file: {$filename}");
         }
 
         // Update global environment
@@ -209,7 +172,7 @@ class Runtime implements RuntimeInterface
 
     protected function loadFile(string $filename, string $ns): void
     {
-        $code = (new CompilerFactory())
+        $code = $this->compilerFactory
             ->createFileCompiler($this->globalEnv)
             ->compile($filename);
 

--- a/src/php/Runtime/Runtime.php
+++ b/src/php/Runtime/Runtime.php
@@ -36,7 +36,7 @@ class Runtime implements RuntimeInterface
         ?string $cacheDirectory = null
     ) {
         set_exception_handler([$this, 'exceptionHandler']);
-        $this->addPath('phel\\', [__DIR__ . '/../phel']);
+        $this->addPath('phel\\', [__DIR__ . '/../../phel']);
 
         $this->globalEnv = $globalEnv;
         $this->exceptionPrinter = $exceptionPrinter;

--- a/src/php/Runtime/RuntimeFactory.php
+++ b/src/php/Runtime/RuntimeFactory.php
@@ -17,6 +17,15 @@ final class RuntimeFactory
 {
     private static ?RuntimeInterface $instance = null;
 
+    public static function getInstance(): RuntimeInterface
+    {
+        if (null === self::$instance) {
+            throw new RuntimeException('Runtime must first be initialized. Call Runtime::initialize()');
+        }
+
+        return self::$instance;
+    }
+
     public static function initialize(
         ?GlobalEnvironmentInterface $globalEnv = null,
         ?string $cacheDirectory = null
@@ -64,14 +73,5 @@ final class RuntimeFactory
     private static function createCompilerFactory(): CompilerFactoryInterface
     {
         return new CompilerFactory();
-    }
-
-    public static function getInstance(): RuntimeInterface
-    {
-        if (null === self::$instance) {
-            throw new RuntimeException('Runtime must first be initialized. Call Runtime::initialize()');
-        }
-
-        return self::$instance;
     }
 }

--- a/src/php/Runtime/RuntimeFactory.php
+++ b/src/php/Runtime/RuntimeFactory.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phel\Runtime;
+
+use Phel\Compiler\CompilerFactory;
+use Phel\Compiler\CompilerFactoryInterface;
+use Phel\Compiler\GlobalEnvironment;
+use Phel\Compiler\GlobalEnvironmentInterface;
+use Phel\Exceptions\ExceptionPrinterInterface;
+use Phel\Exceptions\HtmlExceptionPrinter;
+use Phel\Exceptions\TextExceptionPrinter;
+use RuntimeException;
+
+final class RuntimeFactory
+{
+    private static ?RuntimeInterface $instance = null;
+
+    public static function initialize(
+        ?GlobalEnvironmentInterface $globalEnv = null,
+        ?string $cacheDirectory = null
+    ): RuntimeInterface {
+        if (self::$instance !== null) {
+            throw new RuntimeException('Runtime is already initialized');
+        }
+
+        self::$instance = new Runtime(
+            $globalEnv ?? new GlobalEnvironment(),
+            static::createExceptionPrinter(),
+            static::createCompilerFactory(),
+            $cacheDirectory
+        );
+
+        return self::$instance;
+    }
+
+    private static function createExceptionPrinter(): ExceptionPrinterInterface
+    {
+        if (PHP_SAPI === 'cli') {
+            return TextExceptionPrinter::readableWithStyle();
+        }
+
+        return HtmlExceptionPrinter::create();
+    }
+
+    private static function createCompilerFactory(): CompilerFactoryInterface
+    {
+        return new CompilerFactory();
+    }
+
+    /**
+     * @interal
+     */
+    public static function initializeNew(
+        GlobalEnvironmentInterface $globalEnv,
+        string $cacheDirectory = null
+    ): RuntimeInterface {
+        self::$instance = new Runtime(
+            $globalEnv,
+            self::createExceptionPrinter(),
+            self::createCompilerFactory(),
+            $cacheDirectory
+        );
+
+        return self::$instance;
+    }
+
+    public static function getInstance(): RuntimeInterface
+    {
+        if (null === self::$instance) {
+            throw new RuntimeException('Runtime must first be initialized. Call Runtime::initialize()');
+        }
+
+        return self::$instance;
+    }
+}

--- a/src/php/Runtime/RuntimeFactory.php
+++ b/src/php/Runtime/RuntimeFactory.php
@@ -35,20 +35,6 @@ final class RuntimeFactory
         return self::$instance;
     }
 
-    private static function createExceptionPrinter(): ExceptionPrinterInterface
-    {
-        if (PHP_SAPI === 'cli') {
-            return TextExceptionPrinter::readableWithStyle();
-        }
-
-        return HtmlExceptionPrinter::create();
-    }
-
-    private static function createCompilerFactory(): CompilerFactoryInterface
-    {
-        return new CompilerFactory();
-    }
-
     /**
      * @interal
      */
@@ -64,6 +50,20 @@ final class RuntimeFactory
         );
 
         return self::$instance;
+    }
+
+    private static function createExceptionPrinter(): ExceptionPrinterInterface
+    {
+        if (PHP_SAPI === 'cli') {
+            return TextExceptionPrinter::readableWithStyle();
+        }
+
+        return HtmlExceptionPrinter::create();
+    }
+
+    private static function createCompilerFactory(): CompilerFactoryInterface
+    {
+        return new CompilerFactory();
     }
 
     public static function getInstance(): RuntimeInterface

--- a/src/php/Runtime/RuntimeInterface.php
+++ b/src/php/Runtime/RuntimeInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Phel;
+namespace Phel\Runtime;
 
 use Phel\Compiler\GlobalEnvironmentInterface;
 

--- a/tests/php/Integration/Command/RunCommandTest.php
+++ b/tests/php/Integration/Command/RunCommandTest.php
@@ -8,8 +8,8 @@ use Phel\Command\CommandFactory;
 use Phel\Command\CommandFactoryInterface;
 use Phel\Compiler\CompilerFactory;
 use Phel\Compiler\GlobalEnvironment;
-use Phel\Runtime;
-use Phel\RuntimeInterface;
+use Phel\Runtime\RuntimeFactory;
+use Phel\Runtime\RuntimeInterface;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -74,7 +74,7 @@ final class RunCommandTest extends TestCase
 
     private function createRuntime(): RuntimeInterface
     {
-        return Runtime::initializeNew(new GlobalEnvironment());
+        return RuntimeFactory::initializeNew(new GlobalEnvironment());
     }
 
     private function createCommandFactory(): CommandFactoryInterface

--- a/tests/php/Integration/Command/TestCommandTest.php
+++ b/tests/php/Integration/Command/TestCommandTest.php
@@ -8,7 +8,8 @@ use Phel\Command\CommandFactory;
 use Phel\Command\CommandFactoryInterface;
 use Phel\Compiler\CompilerFactory;
 use Phel\Compiler\GlobalEnvironment;
-use Phel\Runtime;
+use Phel\Runtime\RuntimeFactory;
+use Phel\Runtime\RuntimeInterface;
 use PHPUnit\Framework\TestCase;
 
 final class TestCommandTest extends TestCase
@@ -64,9 +65,9 @@ final class TestCommandTest extends TestCase
         self::assertFalse($testCommand->run([]));
     }
 
-    private function createRuntime(): Runtime
+    private function createRuntime(): RuntimeInterface
     {
-        return Runtime::initializeNew(new GlobalEnvironment());
+        return RuntimeFactory::initializeNew(new GlobalEnvironment());
     }
 
     private function createCommandFactory(string $currentDir): CommandFactoryInterface

--- a/tests/php/Integration/Fixtures/Def/namespace-def.test
+++ b/tests/php/Integration/Fixtures/Def/namespace-def.test
@@ -3,6 +3,6 @@
 
 (def x 1)
 --PHP--
-\Phel\Runtime::getInstance()->getEnv()->setNs("my\\ns");
+\Phel\Runtime\RuntimeFactory::getInstance()->getEnv()->setNs("my\\ns");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "\\my\\ns";
 $GLOBALS["__phel"]["my\\ns"]["x"] = 1;

--- a/tests/php/Integration/Fixtures/Let/loop-destructure.test
+++ b/tests/php/Integration/Fixtures/Let/loop-destructure.test
@@ -7,7 +7,7 @@
   (if x
     (if (php/== x nil) sum (recur xs (php/+ sum x)))))
 --PHP--
-\Phel\Runtime::getInstance()->getEnv()->setNs("test");
+\Phel\Runtime\RuntimeFactory::getInstance()->getEnv()->setNs("test");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "\\test";
 $__phel_1_2 = \Phel\Lang\Tuple::createBracket(1, 2, 3, 4);
 $sum_3 = 0;

--- a/tests/php/Integration/Fixtures/New/new-from-alias.test
+++ b/tests/php/Integration/Fixtures/New/new-from-alias.test
@@ -4,6 +4,6 @@
 
 (php/new DateTimeImmutable "2020-03-22")
 --PHP--
-\Phel\Runtime::getInstance()->getEnv()->setNs("test\\abc");
+\Phel\Runtime\RuntimeFactory::getInstance()->getEnv()->setNs("test\\abc");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "\\test\\abc";
 (new \DateTimeImmutable("2020-03-22"));

--- a/tests/php/Integration/Fixtures/Ns/munge-ns.test
+++ b/tests/php/Integration/Fixtures/Ns/munge-ns.test
@@ -7,8 +7,8 @@
 
 (defstruct abc [a])
 --PHP--
-\Phel\Runtime::getInstance()->loadNs("my-namespace\\core");
-\Phel\Runtime::getInstance()->getEnv()->setNs("hello-world");
+\Phel\Runtime\RuntimeFactory::getInstance()->loadNs("my-namespace\\core");
+\Phel\Runtime\RuntimeFactory::getInstance()->getEnv()->setNs("hello-world");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "\\hello_world";
 $GLOBALS["__phel"]["hello_world"]["x"] = 10;
 $GLOBALS["__phel_meta"]["hello_world"]["x"] = \Phel\Lang\Table::fromKVs(

--- a/tests/php/Integration/Fixtures/Ns/require.test
+++ b/tests/php/Integration/Fixtures/Ns/require.test
@@ -3,7 +3,7 @@
   (:require xzy\core)
   (:require xyz\foo :as f))
 --PHP--
-\Phel\Runtime::getInstance()->loadNs("xzy\\core");
-\Phel\Runtime::getInstance()->loadNs("xyz\\foo");
-\Phel\Runtime::getInstance()->getEnv()->setNs("test");
+\Phel\Runtime\RuntimeFactory::getInstance()->loadNs("xzy\\core");
+\Phel\Runtime\RuntimeFactory::getInstance()->loadNs("xyz\\foo");
+\Phel\Runtime\RuntimeFactory::getInstance()->getEnv()->setNs("test");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "\\test";

--- a/tests/php/Integration/Fixtures/Ns/use.test
+++ b/tests/php/Integration/Fixtures/Ns/use.test
@@ -6,6 +6,6 @@
 (php/new DateTimeImmutable)
 (php/new D)
 --PHP--
-\Phel\Runtime::getInstance()->getEnv()->setNs("test");
+\Phel\Runtime\RuntimeFactory::getInstance()->getEnv()->setNs("test");
 $GLOBALS["__phel"]["phel\\core"]["*ns*"] = "\\test";
 (new DateTimeImmutable());(new DateTime());

--- a/tests/php/Integration/IntegrationTest.php
+++ b/tests/php/Integration/IntegrationTest.php
@@ -12,7 +12,7 @@ use Phel\Compiler\GlobalEnvironment;
 use Phel\Compiler\NodeEnvironment;
 use Phel\Compiler\ReaderInterface;
 use Phel\Lang\Symbol;
-use Phel\Runtime;
+use Phel\Runtime\RuntimeFactory;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -25,7 +25,7 @@ final class IntegrationTest extends TestCase
     {
         Symbol::resetGen();
         $globalEnv = new GlobalEnvironment();
-        $rt = Runtime::initializeNew($globalEnv);
+        $rt = RuntimeFactory::initializeNew($globalEnv);
         $rt->addPath('phel\\', [__DIR__ . '/../../src/phel/']);
         $rt->loadNs('phel\core');
         static::$globalEnv = $globalEnv;

--- a/tests/php/Unit/Runtime/RuntimeMock.php
+++ b/tests/php/Unit/Runtime/RuntimeMock.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PhelTest\Unit;
+namespace PhelTest\Unit\Runtime;
 
 use Phel\Compiler\GlobalEnvironment;
-use Phel\Runtime;
+use Phel\Runtime\Runtime;
 
 final class RuntimeMock extends Runtime
 {

--- a/tests/php/Unit/Runtime/RuntimeTest.php
+++ b/tests/php/Unit/Runtime/RuntimeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhelTest\Unit;
+namespace PhelTest\Unit\Runtime;
 
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
## Description

Issue: https://github.com/jenshaase/phel-composer-plugin/issues/2

In order to decouple the Runtime creation from its logic, I created a new module named Runtime, in which you can find its Factory, the Runtime interface, and the Runtime logic.

## Changes

- Created a Runtime Module with
  - RuntimeFactory <- it creates/initialize the Runtime Singleton
  - Runtime <- it contains the Runtime logic
  - RuntimeInterface <- to invert the Runtime dependencies
- Updated the docu, tests, and namespaces in order to use the `RuntimeFactory` instead of the `Runtime` itself

## QA & Release notes

In order to QA these changes, I changed the `phel/phel-composer-plugin` version branch to the latest one that is using the `RuntimeFactory` as well. Therefore, we need to:
1st) merge the other PR https://github.com/jenshaase/phel-composer-plugin/pull/3
2nd) update this PR: we need to point the plugin to master back again -> `"phel/phel-composer-plugin": "dev-master"` and update it (`composer update phel/phel-composer-plugin`), commit and put the changes.
3rd) once everything is green we are able to merge this PR into `master`.
