### PR TITLE
Bug: Fixes typo in post-global-valid

### DIFF
--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -138,7 +138,7 @@
       (throw (php/new InvalidArgumentException "can not determine HTTP Method")))))
 
 (defn- post-global-valid [method headers]
-  (let [content-type (get headers :conent-type)
+  (let [content-type (get headers :content-type)
         types (php/strtolower (php/trim (first (php/explode ";" content-type 2))))]
     (and
       (= method "POST")


### PR DESCRIPTION
## 📚 Description

When sending a POST request with form data, `(get (http/request-from-globals) :parsed-body)` would always return `nil`.

## 🔖 Changes

- Fixes typo `:conent-type` to `:content-type`. 

Note: Unable to write a test for this without changing phel/http library.

@jenshaase I have managed to write a test for this, but I had to make a small change to `request-from-globals`. I will create a new PR for that change.