### PR TITLE
Adds test for post with form data.

### DIFF
--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -146,11 +146,11 @@
 
 (defn request-from-globals-args
   "Extracts a request from args"
-  [& [_server _get _post _cookies _files]]
-  (let [method (get-method-from-globals _server)
-        uri (uri-from-globals _server)
-        headers (headers-from-server _server)
-        server-protocol (get _server "SERVER_PROTOCOL")
+  [server get-parameter post-parameter cookies files]
+  (let [method (get-method-from-globals server)
+        uri (uri-from-globals server)
+        headers (headers-from-server server)
+        server-protocol (get server "SERVER_PROTOCOL")
         version (if (string? server-protocol)
                   (php/str_replace "HTTP/" "" server-protocol)
                   "1.1")]
@@ -158,11 +158,11 @@
       method
       uri
       headers
-      (when (post-global-valid method headers) (php-array-to-table _post))
-      (php-array-to-table _get)
-      (php-array-to-table _cookies)
-      (php-array-to-table _server)
-      (normalize-files _files)
+      (when (post-global-valid method headers) (php-array-to-table post-parameter))
+      (php-array-to-table get-parameter)
+      (php-array-to-table cookies)
+      (php-array-to-table server)
+      (normalize-files files)
       version)))
 
 (defn request-from-globals

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -144,16 +144,13 @@
       (= method "POST")
       (php/in_array types (php/array "application/x-www-form-urlencoded" "multipart/form-data")))))
 
-
-(defn request-from-globals
-  "Extracts a request from `$_SERVER`"
-  [& [server post]]
-  (let [server (or server php/$_SERVER)
-        method (get-method-from-globals server)
-        uri (uri-from-globals server)
-        headers (headers-from-server server)
-        post (or post php/$_POST)
-        server-protocol (get server "SERVER_PROTOCOL")
+(defn request-from-globals-args
+  "Extracts a request from args"
+  [& [_server _get _post _cookies _files]]
+  (let [method (get-method-from-globals _server)
+        uri (uri-from-globals _server)
+        headers (headers-from-server _server)
+        server-protocol (get _server "SERVER_PROTOCOL")
         version (if (string? server-protocol)
                   (php/str_replace "HTTP/" "" server-protocol)
                   "1.1")]
@@ -161,12 +158,17 @@
       method
       uri
       headers
-      (when (post-global-valid method headers) (php-array-to-table post))
-      (php-array-to-table php/$_GET)
-      (php-array-to-table php/$_COOKIE)
-      (php-array-to-table php/$_SERVER)
-      (normalize-files php/$_FILES)
+      (when (post-global-valid method headers) (php-array-to-table _post))
+      (php-array-to-table _get)
+      (php-array-to-table _cookies)
+      (php-array-to-table _server)
+      (normalize-files _files)
       version)))
+
+(defn request-from-globals
+  "Extracts a request from `$_SERVER`, `$_GET`, `$_POST`, `$_COOKIE` and `$_FILES`"
+  []
+  (request-from-globals-args php/$_SERVER php/$_GET php/$_POST php/$_COOKIE php/$_FILES))
 
 # --------
 # Response

--- a/src/phel/http.phel
+++ b/src/phel/http.phel
@@ -147,11 +147,12 @@
 
 (defn request-from-globals
   "Extracts a request from `$_SERVER`"
-  [& [server]]
+  [& [server post]]
   (let [server (or server php/$_SERVER)
         method (get-method-from-globals server)
         uri (uri-from-globals server)
         headers (headers-from-server server)
+        post (or post php/$_POST)
         server-protocol (get server "SERVER_PROTOCOL")
         version (if (string? server-protocol)
                   (php/str_replace "HTTP/" "" server-protocol)
@@ -160,7 +161,7 @@
       method
       uri
       headers
-      (when (post-global-valid method headers) (php-array-to-table php/$_POST))
+      (when (post-global-valid method headers) (php-array-to-table post))
       (php-array-to-table php/$_GET)
       (php-array-to-table php/$_COOKIE)
       (php-array-to-table php/$_SERVER)

--- a/tests/phel/test/http.phel
+++ b/tests/phel/test/http.phel
@@ -230,7 +230,7 @@
   (is
     (=
       "GET"
-      (get (h/request-from-globals (php-associative-array
+      (get (h/request-from-globals-args (php-associative-array
         "REQUEST_METHOD" "GET"
       )) :method)
     )
@@ -240,7 +240,7 @@
   (is
     (=
       "POST"
-      (get (h/request-from-globals (php-associative-array
+      (get (h/request-from-globals-args (php-associative-array
         "REQUEST_METHOD" "POST"
       )) :method)
     )
@@ -251,10 +251,11 @@
     (=
       @{"name" "phel"  "type" "lang"}
       (get
-        (h/request-from-globals
+        (h/request-from-globals-args
           (php-associative-array
             "REQUEST_METHOD" "POST"
             "CONTENT_TYPE" "multipart/form-data")
+          (php/array)
           (php-associative-array
             "name" "phel"
             "type" "lang"))
@@ -265,7 +266,7 @@
   (is
     (=
       "1.1"
-      (get (h/request-from-globals (php-associative-array
+      (get (h/request-from-globals-args (php-associative-array
         "SERVER_PROTOCOL" "HTTP/1.1"
         "REQUEST_METHOD" "GET"
       )) :version)
@@ -276,7 +277,7 @@
   (is
     (=
       "2.0"
-      (get (h/request-from-globals (php-associative-array
+      (get (h/request-from-globals-args (php-associative-array
         "SERVER_PROTOCOL" "HTTP/2.0"
         "REQUEST_METHOD" "GET"
       )) :version)

--- a/tests/phel/test/http.phel
+++ b/tests/phel/test/http.phel
@@ -246,6 +246,21 @@
     )
     "request method post"))
 
+(deftest test-request-post-with-form-data
+  (is
+    (=
+      @{"name" "phel"  "type" "lang"}
+      (get
+        (h/request-from-globals
+          (php-associative-array
+            "REQUEST_METHOD" "POST"
+            "CONTENT_TYPE" "multipart/form-data")
+          (php-associative-array
+            "name" "phel"
+            "type" "lang"))
+        :parsed-body))
+    "request method post with form data"))
+
 (deftest test-request-server-protocol-1
   (is
     (=

--- a/tests/phel/test/http.phel
+++ b/tests/phel/test/http.phel
@@ -230,20 +230,28 @@
   (is
     (=
       "GET"
-      (get (h/request-from-globals-args (php-associative-array
-        "REQUEST_METHOD" "GET"
-      )) :method)
-    )
+      (get
+        (h/request-from-globals-args
+          (php-associative-array "REQUEST_METHOD" "GET")
+          (php-associative-array)
+          (php-associative-array)
+          (php-associative-array)
+          (php-associative-array))
+        :method))
     "request method get"))
 
 (deftest test-request-post
   (is
     (=
       "POST"
-      (get (h/request-from-globals-args (php-associative-array
-        "REQUEST_METHOD" "POST"
-      )) :method)
-    )
+      (get
+        (h/request-from-globals-args
+          (php-associative-array "REQUEST_METHOD" "POST")
+          (php-associative-array)
+          (php-associative-array)
+          (php-associative-array)
+          (php-associative-array))
+        :method))
     "request method post"))
 
 (deftest test-request-post-with-form-data
@@ -255,10 +263,12 @@
           (php-associative-array
             "REQUEST_METHOD" "POST"
             "CONTENT_TYPE" "multipart/form-data")
-          (php/array)
+          (php-associative-array)
           (php-associative-array
             "name" "phel"
-            "type" "lang"))
+            "type" "lang")
+          (php-associative-array)
+          (php-associative-array))
         :parsed-body))
     "request method post with form data"))
 
@@ -266,22 +276,32 @@
   (is
     (=
       "1.1"
-      (get (h/request-from-globals-args (php-associative-array
-        "SERVER_PROTOCOL" "HTTP/1.1"
-        "REQUEST_METHOD" "GET"
-      )) :version)
-    )
+      (get
+        (h/request-from-globals-args
+          (php-associative-array
+            "SERVER_PROTOCOL" "HTTP/1.1"
+            "REQUEST_METHOD" "GET")
+          (php-associative-array)
+          (php-associative-array)
+          (php-associative-array)
+          (php-associative-array))
+        :version))
     "server protocol 1.1"))
 
 (deftest test-request-server-protocol-2
   (is
     (=
       "2.0"
-      (get (h/request-from-globals-args (php-associative-array
-        "SERVER_PROTOCOL" "HTTP/2.0"
-        "REQUEST_METHOD" "GET"
-      )) :version)
-    )
+      (get
+        (h/request-from-globals-args
+          (php-associative-array
+            "SERVER_PROTOCOL" "HTTP/2.0"
+            "REQUEST_METHOD" "GET")
+          (php-associative-array)
+          (php-associative-array)
+          (php-associative-array)
+          (php-associative-array))
+        :version))
     "server protocol 2.0"))
 
 # --------


### PR DESCRIPTION
## 📚 Description

It adds a test for issue fixed in this PR #135.

## 🔖 Changes

- Adds test for post with form data. 
- Adds `post` parameter to `request-from-globals` in order to be able to test it. @jenshaase This seemed like the fastest way of doing this. We could add a method like `get-post-from-globals` like we have `get-method-from-globals`, but this seemed simpler. Open for suggestions.
