### PR TITLE
Implement str-contains? in phel

### DIFF
--- a/doc/content/documentation/api.md
+++ b/doc/content/documentation/api.md
@@ -689,6 +689,13 @@ Shorthand for `(if (not condition) else then)`.
 ```
 Increments `x` by one.
 
+## `includes?`
+
+```phel
+(includes? s substr)
+```
+True if s includes substr.
+
 ## `indexed?`
 
 ```phel

--- a/doc/content/documentation/api.md
+++ b/doc/content/documentation/api.md
@@ -689,13 +689,6 @@ Shorthand for `(if (not condition) else then)`.
 ```
 Increments `x` by one.
 
-## `includes?`
-
-```phel
-(includes? s substr)
-```
-True if s includes substr.
-
 ## `indexed?`
 
 ```phel
@@ -1218,6 +1211,13 @@ Creates a string by concatenating values together. If no arguments are
 provided an empty string is returned. Nil and false are represented as empty
 string. True is represented as 1. Otherwise it tries to call `__toString`.
 This is PHP equivalent to `$args[0] . $args[1] . $args[2] ...`
+
+## `str-contains?`
+
+```phel
+(str-contains? str s)
+```
+True if str contains s.
 
 ## `string?`
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -476,10 +476,10 @@ Calling the and function without arguments returns true."
   [x]
   (id x false))
 
-(defn includes?
-  "True if s includes substr."
-  [s substr]
-  (not (false? (php/strpos substr s))))
+(defn str-contains?
+  "True if str contains s."
+  [str s]
+  (not (false? (php/strpos str s))))
 
 (defn compare
   "An integer less than, equal to, or greater than zero when `x` is less than,

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -476,6 +476,11 @@ Calling the and function without arguments returns true."
   [x]
   (id x false))
 
+(defn includes?
+  "True if s includes substr."
+  [s substr]
+  (not (false? (php/strpos substr s))))
+
 (defn compare
   "An integer less than, equal to, or greater than zero when `x` is less than,
   equal to, or greater than `y`, respectively."

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -279,9 +279,9 @@
   (is (= false (false? nil)) "(false? nil)")
   (is (= false (false? true)) "(false? true)"))
 
-(deftest test-includes?
-   (is (true? (includes? "a" "abc")))
-   (is (false? (includes? "d" "abc"))))
+(deftest test-str-contains?
+   (is (true? (str-contains? "abc" "a")))
+   (is (false? (str-contains? "abc" "d"))))
 
 (deftest test-compare
   (is (= -1 (compare 1 2)) "(compare 1 2)")

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -279,6 +279,10 @@
   (is (= false (false? nil)) "(false? nil)")
   (is (= false (false? true)) "(false? true)"))
 
+(deftest test-includes?
+   (is (true? (includes? "a" "abc")))
+   (is (false? (includes? "d" "abc"))))
+
 (deftest test-compare
   (is (= -1 (compare 1 2)) "(compare 1 2)")
   (is (= 1 (compare 2 1)) "(compare 2 1)")


### PR DESCRIPTION
## 📚  Description

I was thinking about to implement something like the new [`str_contains`](https://www.php.net/manual/en/function.str-contains) (able in PHP 8). So I did.

## 🔖 Changes

- Added the `str-contains?` function in phel with some unit tests
- Updated the API docu using `php doc/build-api-page.php > doc/content/documentation/api.md`
