### PR TITLE
Adding argv to the core

### DIFF
--- a/doc/content/documentation/api.md
+++ b/doc/content/documentation/api.md
@@ -137,6 +137,10 @@ returns logical false, and returns that value and doesn't evaluate any of the
 other expressions, otherwise it returns the value of the last expression.
 Calling the and function without arguments returns true.
 
+## `argv`
+
+Array of arguments passed to script.
+
 ## `array`
 
 ```phel

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -28,6 +28,10 @@
 
 (def *ns* "\\phel\\core")
 
+(def argv
+  "Array of arguments passed to script."
+  (php/aget php/$GLOBALS "argv"))
+
 # --------------------------------------------
 # Basic methods for quasiquote and destructure
 # --------------------------------------------


### PR DESCRIPTION
## 📚 Description

🍨 Issue: https://github.com/jenshaase/phel-lang/issues/161 

Be able to use [$argv](https://www.php.net/manual/en/reserved.variables.argv.php) from phel 

## 🔖 Changes

- Added `argv` as constant in `core.phel`.

## 💡 Extra

As a follow-up idea we could develop a library to parse key-value arguments. Something like
```bash
 php phel run src/phel/local.phel k1=v1 k2=v2
```

And (parse-key-values argv), as simple example:
```
# (php/dump (parse-key-values argv))

array:5 [
  0 => "phel"
  1 => "run"
  2 => "src/phel/local.phel"
  'k1' => "v1"
  'k2' => "v2"
]
```
