### PR TITLE
Fixes typo.

### DIFF
--- a/doc/content/documentation/array-table-and-struct.md
+++ b/doc/content/documentation/array-table-and-struct.md
@@ -193,7 +193,7 @@ A struct is a special kind of table. It only supports a predefined number of key
 
 ```phel
 (defstruct my-struct [a b c]) # Defines the struct
-(let [x (my_struct 1 2 3)] # Create a new struct
+(let [x (my-struct 1 2 3)] # Create a new struct
   (my-struct? x) # Evaluates to true
   (get x :a) # Evaluates to 1
   (put x :a 12) # Evaluates to (my-struct 12 2 3)


### PR DESCRIPTION
I think that this is a typo.

## 📚 Description

Fixes typo in documentation for Array, Table, Struct and Set.

## 🔖 Changes

- Changes `my_struct` to `my-struct`.
