### PR TITLE
Remove array_merge from loop

### DIFF
--- a/src/php/Command/Shared/NamespaceExtractor.php
+++ b/src/php/Command/Shared/NamespaceExtractor.php
@@ -76,10 +76,10 @@ final class NamespaceExtractor implements NamespaceExtractorInterface
         $testDirectories = $config['tests'] ?? [];
         foreach ($testDirectories as $testDir) {
             $allNamespacesInDir = $this->findAllNs($currentDir . $testDir);
-            $namespaces = array_merge($namespaces, $allNamespacesInDir);
+            $namespaces[] = $allNamespacesInDir;
         }
 
-        return $namespaces;
+        return array_merge(...array_values($namespaces));
     }
 
     private function findAllNs(string $directory): array
@@ -97,12 +97,12 @@ final class NamespaceExtractor implements NamespaceExtractorInterface
     {
         $composerContent = file_get_contents($currentDirectory . 'composer.json');
         if (!$composerContent) {
-            throw new \Exception('Can not read composer.json in: ' . $currentDirectory);
+            throw new \Exception('Cannot read composer.json in: ' . $currentDirectory);
         }
 
         $composerData = json_decode($composerContent, true);
         if (!$composerData) {
-            throw new \Exception('Can not parse composer.json in: ' . $currentDirectory);
+            throw new \Exception('Cannot parse composer.json in: ' . $currentDirectory);
         }
 
         if (isset($composerData['extra']['phel'])) {


### PR DESCRIPTION
## 📚 Description

I noticed [PHP Extensions (EA Extended)](https://plugins.jetbrains.com/plugin/7622-php-inspections-ea-extended-) plugin was notifying it's not recommended to use `array_merge` function inside loops.
If you think, it makes sense, you are overriding the same array with the same data plus the new value over and over for each loop iteration.

![image](https://user-images.githubusercontent.com/6381924/104435979-53d2b680-558d-11eb-98d0-d2a81b9dfbac.png)

## 🐘  Reference
 - [Never Use array_merge in a Loop | Chemaclass](https://medium.com/swlh/never-use-array-merge-in-a-loop-74917b056ff9)
