### PR TITLE
Added format + printf phel functions

### DIFF
--- a/doc/content/documentation/api.md
+++ b/doc/content/documentation/api.md
@@ -509,7 +509,7 @@ List comprehension. The head of the loop is a tuple that contains a
 ```phel
 (format fmt & xs)
 ```
-Returns a string produced according to the formatting string fmt.
+Returns a formatted string. See PHP's [sprintf](https://www.php.net/manual/en/function.sprintf.php) for more information.
 
 ## `frequencies`
 
@@ -1046,7 +1046,7 @@ Same as print. But instead of writing it to a output stream,
 ```phel
 (printf fmt & xs)
 ```
-Output a formatted string.
+Output a formatted string. See PHP's [printf](https://www.php.net/manual/en/function.printf.php) for more information.
 
 ## `println`
 

--- a/doc/content/documentation/api.md
+++ b/doc/content/documentation/api.md
@@ -504,6 +504,13 @@ List comprehension. The head of the loop is a tuple that contains a
 
   The for loops returns a array with all evaluated elements of the body.
 
+## `format`
+
+```phel
+(format fmt & xs)
+```
+Returns a string produced according to the formatting string fmt.
+
 ## `frequencies`
 
 ```phel
@@ -1033,6 +1040,13 @@ Prints the given values to the default output stream. Returns nil.
 ```
 Same as print. But instead of writing it to a output stream,
   The resulting string is returned.
+
+## `printf`
+
+```phel
+(printf fmt & xs)
+```
+Output a formatted string.
 
 ## `println`
 

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1376,14 +1376,14 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   nil)
 
 (defn format
-  "Returns a string produced according to the formatting string fmt."
+  "Returns a formatted string. See PHP's [sprintf](https://www.php.net/manual/en/function.sprintf.php) for more information."
   [fmt & xs]
   (apply php/sprintf fmt xs))
 
 (defn printf
-  "Output a formatted string."
+  "Output a formatted string. See PHP's [printf](https://www.php.net/manual/en/function.printf.php) for more information."
   [fmt & xs]
-  (php/print (apply format fmt xs))
+  (apply php/printf fmt xs)
   nil)
 
 # ----------------

--- a/src/phel/core.phel
+++ b/src/phel/core.phel
@@ -1375,6 +1375,17 @@ returns 1. If `xs` has one value, returns the reciprocal of x."
   (php/print "\n")
   nil)
 
+(defn format
+  "Returns a string produced according to the formatting string fmt."
+  [fmt & xs]
+  (apply php/sprintf fmt xs))
+
+(defn printf
+  "Output a formatted string."
+  [fmt & xs]
+  (php/print (apply format fmt xs))
+  nil)
+
 # ----------------
 # Threading macros
 # ----------------

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -933,6 +933,24 @@
 (deftest test-println
   (is (output? "hello\nworld\n" (println "hello\nworld")) "println hello\\nworld"))
 
+(deftest test-format
+  (is (= "" (format "" "hello")) "format with empty fmt")
+  (is (= "hello\nworld" (format "%s" "hello\nworld")) "format one string")
+  (is (= "hello 1" (format "%s %d" "hello" 1)) "format with different types")
+  (is (= "[\"a\" \"b\"]" (format "%s" ["a" "b"])) "format with tuple of strings")
+  (is (= "@[\"a\" \"b\"]" (format "%s" @["a" "b"])) "format with array of strings")
+  (is (= "@{\"a\" \"b\"}" (format "%s" @{"a" "b"})) "format on table")
+  (is (= "(set \"a\" \"b\")" (format "%s" (set "a" "b"))) "format on set")
+  (is (= "x" (format "%s" 'x)) "format on symbol")
+  (is (= ":test" (format "%s" :test)) "format on keyword")
+  (is (= "1" (format "%d" 1)) "format on number")
+  (is (= "1" (format "%d" true)) "format on true")
+  (is (= "0" (format "%d" false)) "format on false")
+  (is (= "" (format "%s" nil)) "format on nil"))
+
+(deftest test-printf
+  (is (output? "hello\nworld" (printf "%s\n%s" "hello" "world")) "printf hello\\nworld"))
+
 (defstruct my-struct [a b c])
 
 (deftest test-struct

--- a/tests/phel/test/core.phel
+++ b/tests/phel/test/core.phel
@@ -934,7 +934,8 @@
   (is (output? "hello\nworld\n" (println "hello\nworld")) "println hello\\nworld"))
 
 (deftest test-format
-  (is (= "" (format "" "hello")) "format with empty fmt")
+  (is (= "" (format "")) "format with empty fmt")
+  (is (= "" (format "" "hello")) "format with empty fmt and one arg")
   (is (= "hello\nworld" (format "%s" "hello\nworld")) "format one string")
   (is (= "hello 1" (format "%s %d" "hello" 1)) "format with different types")
   (is (= "[\"a\" \"b\"]" (format "%s" ["a" "b"])) "format with tuple of strings")


### PR DESCRIPTION
## 📚 Description

Added some more `Phel` functions to the core.

## 🔖 Changes

- Added `format`: Returns a string produced according to the formatting string fmt.
- Added `printf`: Output a formatted string.

<img width="609" alt="Screenshot 2021-01-14 at 08 00 52" src="https://user-images.githubusercontent.com/5256287/104555722-a28c5900-563e-11eb-9561-ae7f2ab17b2b.png">

<img width="587" alt="Screenshot 2021-01-14 at 08 01 48" src="https://user-images.githubusercontent.com/5256287/104555809-c3ed4500-563e-11eb-8dbc-85c7844043ac.png">
