### PR TITLE
Installing phpmetrics in require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "vimeo/psalm": "dev-master",
         "friendsofphp/php-cs-fixer": "^2.16",
         "infection/infection": "^0.16.3 || ^0.20.0",
-        "symfony/var-dumper": "^5.2"
+        "symfony/var-dumper": "^5.2",
+        "phpmetrics/phpmetrics": "^2.7"
     },
     "autoload": {
         "psr-4": {
@@ -48,7 +49,8 @@
         "test-core": "./phel test",
         "psalm": "./vendor/bin/psalm",
         "csfix": "./vendor/bin/php-cs-fixer fix",
-        "csrun": "./vendor/bin/php-cs-fixer fix --dry-run"
+        "csrun": "./vendor/bin/php-cs-fixer fix --dry-run",
+        "metrics-report": "./vendor/bin/phpmetrics --report-html=data/metrics-report src/php"
     },
     "bin": [
         "phel"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "908f9337bb444e888ad472db3d5b4532",
+    "content-hash": "aa1ca1906028a289bcf44e9e4cf3d5e9",
     "packages": [
         {
             "name": "phel/phel-composer-plugin",
@@ -1845,6 +1845,73 @@
                 "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
             },
             "time": "2020-09-17T18:55:26+00:00"
+        },
+        {
+            "name": "phpmetrics/phpmetrics",
+            "version": "v2.7.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpmetrics/PhpMetrics.git",
+                "reference": "e6a7aee0e0948e363eb78ce9d58573cd5af2cdec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpmetrics/PhpMetrics/zipball/e6a7aee0e0948e363eb78ce9d58573cd5af2cdec",
+                "reference": "e6a7aee0e0948e363eb78ce9d58573cd5af2cdec",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "nikic/php-parser": "^3|^4",
+                "php": ">=5.5"
+            },
+            "replace": {
+                "halleck45/php-metrics": "*",
+                "halleck45/phpmetrics": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14",
+                "sebastian/comparator": ">=1.2.3",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "bin": [
+                "bin/phpmetrics"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Hal\\": "./src/"
+                },
+                "files": [
+                    "./src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jean-François Lépine",
+                    "email": "lepinejeanfrancois@yahoo.fr",
+                    "homepage": "http://www.lepine.pro",
+                    "role": "Copyright Holder"
+                }
+            ],
+            "description": "Static analyzer tool for PHP : Coupling, Cyclomatic complexity, Maintainability Index, Halstead's metrics... and more !",
+            "homepage": "http://www.phpmetrics.org",
+            "keywords": [
+                "analysis",
+                "qa",
+                "quality",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/PhpMetrics/PhpMetrics/issues",
+                "source": "https://github.com/phpmetrics/PhpMetrics/tree/master"
+            },
+            "time": "2020-06-30T20:33:55+00:00"
         },
         {
             "name": "phpspec/prophecy",


### PR DESCRIPTION
## 📚 Description

Installing for dev purposes this tool https://github.com/phpmetrics/phpmetrics, which provides a lot of nice metrics for the project. You can see what metrics you can find here https://github.com/phpmetrics/PhpMetrics/blob/master/doc/metrics.md

## 🔖 Changes

- Added latest version of `phpmetrics/phpmetrics` to `require-dev`
- Added a composer script alias `composer metrics-report` which runs: 
  - `./vendor/bin/phpmetrics --report-html=data/metrics-report src/php`

Because it's a `require-dev` it won't have any impact on the users of `phel` when downloading as a dependency itself.

## 🖼️  An example of the current overview

<img width="1790" alt="Screenshot 2021-01-19 at 14 34 39" src="https://user-images.githubusercontent.com/5256287/105041596-79673080-5a63-11eb-808f-3baa86379696.png">

