### PR TITLE
Add infection to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         ],
         "test-compiler": "./vendor/bin/phpunit",
         "test-compiler:coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-html data/coverage-report",
+        "test-infection": "XDEBUG_MODE=coverage ./vendor/bin/infection",
         "test-core": "./phel test",
         "psalm": "./vendor/bin/psalm",
         "csfix": "./vendor/bin/php-cs-fixer fix --allow-risky=yes",


### PR DESCRIPTION
## 📚 Description

`infection` was not "enabled" in the composer scripts because it was not working.

The problem was I/we missed to add the `XDEBUG_MODE=coverage` flag to make it works. With the flag, `infection` works like a charm.

[Here is the issue](https://github.com/infection/infection/issues/1473#event-4233608893) I opened in the infection project about how to solve this problem. 😃 
